### PR TITLE
fix: proper reading for paginated members response

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -55,17 +55,14 @@
         "properties": {
           "baseUrl": {
             "description": "Returns the base URL constructed with the extension context",
-            "example": "/polarion/pdf-exporter",
             "type": "string"
           },
           "extensionContext": {
             "description": "The extension context used as a base for URL construction",
-            "example": "pdf-exporter",
             "type": "string"
           },
           "restUrl": {
             "description": "Returns the REST API URL constructed with the extension context",
-            "example": "/polarion/pdf-exporter/rest",
             "type": "string"
           },
           "swaggerUiUrl": {

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
@@ -24,6 +24,7 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -86,7 +87,15 @@ public class GraphConnector implements IGraphConnector {
         String selectValue = "%s,%s,%s".formatted(id, name, email);
         String searchResult = fetchMSGraphApi(url, "$select", selectValue, String.class);
         MemberResponseWrapper memberResponseWrapper = MemberResponseWrapper.fromJsonList(searchResult, fieldsMapping);
-        return memberResponseWrapper.getValue();
+
+        List<Member> members = new ArrayList<>(memberResponseWrapper.getValue());
+        while (memberResponseWrapper.getNextLink() != null) {
+            searchResult = fetchMSGraphApi(memberResponseWrapper.getNextLink(), null, null, String.class);
+            memberResponseWrapper = MemberResponseWrapper.fromJsonList(searchResult, fieldsMapping);
+            members.addAll(memberResponseWrapper.getValue());
+        }
+
+        return members;
     }
 
     @Override

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/model/MemberResponseWrapper.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/model/MemberResponseWrapper.java
@@ -4,7 +4,6 @@ import ch.sbb.polarion.extension.aad.synchronizer.utils.JsonListParser;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -19,8 +18,6 @@ public class MemberResponseWrapper implements PageableWrapper {
     public static final String EMAIL = "email";
 
     private List<Member> value;
-
-    @Setter
     private String nextLink;
 
     public static @NotNull MemberResponseWrapper fromJsonList(@NotNull String json, @NotNull Map<String, String> fieldsMapping) {

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/model/MemberResponseWrapper.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/model/MemberResponseWrapper.java
@@ -4,6 +4,7 @@ import ch.sbb.polarion.extension.aad.synchronizer.utils.JsonListParser;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -12,12 +13,15 @@ import java.util.Map;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class MemberResponseWrapper {
+public class MemberResponseWrapper implements PageableWrapper {
     public static final String ID = "id";
     public static final String NAME = "name";
     public static final String EMAIL = "email";
 
     private List<Member> value;
+
+    @Setter
+    private String nextLink;
 
     public static @NotNull MemberResponseWrapper fromJsonList(@NotNull String json, @NotNull Map<String, String> fieldsMapping) {
         return JsonListParser.parseList(json, fieldsMapping, MemberResponseWrapper.class, Member.class);

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/model/PageableWrapper.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/model/PageableWrapper.java
@@ -1,0 +1,11 @@
+package ch.sbb.polarion.extension.aad.synchronizer.model;
+
+/**
+ * Marks a class as being able to provide a next link.
+ */
+public interface PageableWrapper {
+
+    String getNextLink();
+
+    void setNextLink(String nextLink);
+}

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/utils/JsonListParser.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/utils/JsonListParser.java
@@ -1,7 +1,9 @@
 package ch.sbb.polarion.extension.aad.synchronizer.utils;
 
+import ch.sbb.polarion.extension.aad.synchronizer.model.PageableWrapper;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.polarion.core.util.StringUtils;
 import lombok.SneakyThrows;
 import lombok.experimental.UtilityClass;
 import org.jetbrains.annotations.NotNull;
@@ -15,15 +17,23 @@ import java.util.Map;
 @UtilityClass
 public class JsonListParser {
     public static final String VALUE = "value";
-
-    public @NotNull <W, E> W parseList(@NotNull String json, @NotNull Map<String, String> fieldsMapping, @NotNull Class<W> wrapperClass, @NotNull Class<E> elementClass) {
-        return parseList(json, VALUE, fieldsMapping, wrapperClass, elementClass);
-    }
+    public static final String NEXT_LINK = "@odata.nextLink";
 
     @SneakyThrows
-    public @NotNull <W, E> W parseList(@NotNull String json, @NotNull String containerName, @NotNull Map<String, String> fieldsMapping, Class<W> wrapperClass, Class<E> elementClass) {
-        ObjectMapper objectMapper = new ObjectMapper();
-        JsonNode rootNode = objectMapper.readTree(json);
+    public @NotNull <W, E> W parseList(@NotNull String json, @NotNull Map<String, String> fieldsMapping, @NotNull Class<W> wrapperClass, @NotNull Class<E> elementClass) {
+        JsonNode rootNode = getObjectMapper().readTree(json);
+        W wrapper = parseList(rootNode, VALUE, fieldsMapping, wrapperClass, elementClass);
+        if (wrapper instanceof PageableWrapper pageableWrapper) {
+            String nextLink = getFieldValue(rootNode, NEXT_LINK);
+            if (!StringUtils.isEmpty(nextLink)) {
+                pageableWrapper.setNextLink(nextLink);
+            }
+        }
+        return wrapper;
+    }
+
+    public @NotNull <W, E> W parseList(@NotNull JsonNode rootNode, @NotNull String containerName, @NotNull Map<String, String> fieldsMapping, Class<W> wrapperClass, Class<E> elementClass) {
+        ObjectMapper objectMapper = getObjectMapper();
         List<E> items = new ArrayList<>();
 
         if (rootNode.has(containerName)) {
@@ -55,5 +65,9 @@ public class JsonListParser {
         } else {
             return null;
         }
+    }
+
+    private ObjectMapper getObjectMapper() {
+        return new ObjectMapper();
     }
 }

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
@@ -95,6 +95,17 @@ class GraphConnectorTest {
     }
 
     @Test
+    void getPaginatedMembers() throws IOException {
+        String memberId = "memberId";
+        mockGetMemberCall(memberId, "membersPaginated.json", 200);
+        mockGetMemberCall("next", "members.json", 200);
+
+        List<Member> memberList = graphConnector.getMembers(memberId);
+
+        assertThat(memberList).hasSize(8);
+    }
+
+    @Test
     void getMembersWithWrongStatusCode() throws IOException {
         String memberId = "memberId";
         mockGetMemberCall(memberId, "emptyMembersList.json", 222);

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/model/MemberResponseWrapperTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/model/MemberResponseWrapperTest.java
@@ -11,8 +11,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static ch.sbb.polarion.extension.aad.synchronizer.model.MemberResponseWrapper.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 class MemberResponseWrapperTest {
 
@@ -30,13 +29,29 @@ class MemberResponseWrapperTest {
             assertNotNull(memberResponseWrapper);
             List<Member> members = memberResponseWrapper.getValue();
             assertEquals(5, members.size());
-            assertEquals("https://graph.microsoft.com/v1.0/users?$skip=5", memberResponseWrapper.getNextLink());
+            assertNull(memberResponseWrapper.getNextLink());
             Optional<Member> johnDoe = members.stream()
                     .filter(member -> member.getEmail().equals("john.doe@example.com"))
                     .findFirst();
             Assertions.assertTrue(johnDoe.isPresent());
             assertEquals("jdoe", johnDoe.get().getId());
             assertEquals("John Doe", johnDoe.get().getName());
+        }
+    }
+
+    @Test
+    void testParseNextLink() throws IOException {
+        Map<String, String> fieldsMapping = Map.ofEntries(
+                Map.entry(ID, "mailNickname"),
+                Map.entry(NAME, "displayName"),
+                Map.entry(EMAIL, "mail")
+        );
+
+        try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream("membersPaginated.json")) {
+            String content = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
+            MemberResponseWrapper memberResponseWrapper = MemberResponseWrapper.fromJsonList(content, fieldsMapping);
+            assertNotNull(memberResponseWrapper);
+            assertEquals("http://localhost:1080/v1.0/groups/next/members", memberResponseWrapper.getNextLink());
         }
     }
 }

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/model/MemberResponseWrapperTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/model/MemberResponseWrapperTest.java
@@ -30,6 +30,7 @@ class MemberResponseWrapperTest {
             assertNotNull(memberResponseWrapper);
             List<Member> members = memberResponseWrapper.getValue();
             assertEquals(5, members.size());
+            assertEquals("https://graph.microsoft.com/v1.0/users?$skip=5", memberResponseWrapper.getNextLink());
             Optional<Member> johnDoe = members.stream()
                     .filter(member -> member.getEmail().equals("john.doe@example.com"))
                     .findFirst();

--- a/src/test/resources/members.json
+++ b/src/test/resources/members.json
@@ -1,5 +1,6 @@
 {
   "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#directoryObjects(displayName,mail,mailNickname)",
+  "@odata.nextLink": "https://graph.microsoft.com/v1.0/users?$skip=5",
   "value": [
     {
       "@odata.type": "#microsoft.graph.user",

--- a/src/test/resources/membersPaginated.json
+++ b/src/test/resources/membersPaginated.json
@@ -1,5 +1,6 @@
 {
   "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#directoryObjects(displayName,mail,mailNickname)",
+  "@odata.nextLink": "http://localhost:1080/v1.0/groups/next/members",
   "value": [
     {
       "@odata.type": "#microsoft.graph.user",
@@ -18,18 +19,6 @@
       "displayName": "IT Support",
       "mail": "support@example.com",
       "mailNickname": "itsupport"
-    },
-    {
-      "@odata.type": "#microsoft.graph.user",
-      "displayName": "Alice Johnson",
-      "mail": "alice.johnson@example.com",
-      "mailNickname": "ajohnson"
-    },
-    {
-      "@odata.type": "#microsoft.graph.user",
-      "displayName": "Bob Williams",
-      "mail": "bob.williams@example.com",
-      "mailNickname": "bwilliams"
     }
   ]
 }


### PR DESCRIPTION
Refs: #39

### Proposed changes

We need properly process paginated responses to find all users in a group.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
