### PR TITLE
fix: support for Azure AD directory schema extension attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ dependency-reduced-pom.xml
 
 src/main/resources/webapp/*-admin/html/about.html
 README.html
+
+# Local secrets for the integration-test profile (GraphConnectorIT). The committed
+# aad-sync-it.properties.example serves as the template — copy it and fill in real values.
+aad-sync-it.properties

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=SchweizerischeBundesbahnen_ch.sbb.polarion.extension.aad-synchronizer&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=SchweizerischeBundesbahnen_ch.sbb.polarion.extension.aad-synchronizer)
 [![Vulnerabilities](https://sonarcloud.io/api/project_badges/measure?project=SchweizerischeBundesbahnen_ch.sbb.polarion.extension.aad-synchronizer&metric=vulnerabilities)](https://sonarcloud.io/summary/new_code?id=SchweizerischeBundesbahnen_ch.sbb.polarion.extension.aad-synchronizer)
 
-# Synchronization user job between Azure AD and Polarion
+# User synchronization job between Azure AD and Polarion
 
-This Polarion job synchronizes deleted (or marked as inactive) Azure AD users with Polarion
+This Polarion job synchronizes users between Azure AD groups and Polarion: it creates Polarion accounts
+for users that were added to the configured AAD groups and removes (or marks as inactive) Polarion
+accounts for users that no longer belong to any of those groups.
 
 > [!IMPORTANT]
 > Starting from version 3.0.0 only latest version of Polarion is supported.
@@ -48,11 +50,15 @@ Changes only take effect after restart of Polarion.
 
 ## Polarion configuration
 
-For using this job you can go in the global `Administration` / `Scheduler` to run regularly like this:
+To run this job on a schedule, configure it in the global `Administration` / `Scheduler` as follows:
 
 ```xml
 <job id="aad_user_synchronization.job" cronExpression="0 0 0 * * ?" name="AAD Synchronization" scope="system">
     <authenticationProviderId>oauth2</authenticationProviderId>
+
+    <!-- Optional: enable directory schema extension expansion (see "Custom extension attributes" below) -->
+    <extensionAppId>abc123de-f456-7890-abcd-ef1234567890</extensionAppId>
+    <extensionFields>id</extensionFields>
 
     <groupPrefix>SOME_GROUP_PREFIX_</groupPrefix>
 
@@ -78,13 +84,13 @@ For using this job you can go in the global `Administration` / `Scheduler` to ru
 
 ### Parameters overview
 
-This configuration defines the parameters for a job that synchronizes users from Azure Active Directory (AAD) to the Polarion.
+This configuration defines the parameters for the job that synchronizes users from Azure Active Directory (AAD) to Polarion.
 
 #### Authentication Provider Configuration
 
-- **Authentication Provider** (`authenticationProviderId`): Authentication Provider from `authentication.xml` to obtain authentication tokens for Azure Graph API and field mappings.
+- **Authentication Provider** (`authenticationProviderId`): the OAuth2 provider from `authentication.xml` used to obtain authentication tokens for the Microsoft Graph API and to determine the field mappings.
 
-Extension uses `tokenUrl`, `clientId`, `clientSecret`, `scope` and `mapping` for connection to MS Graph API.
+The extension uses `tokenUrl`, `clientId`, `clientSecret`, `scope` and `mapping` from this provider to talk to the MS Graph API.
 
 Example of `authentication.xml`:
 
@@ -133,6 +139,57 @@ Example of `authentication.xml`:
     </oauth2>
 </authentication>
 ```
+
+#### Custom extension attributes
+
+The fields configured in the `<mapping>` block of `authentication.xml` are used by the synchronization
+job as Microsoft Graph property names when fetching user data from `/users/{id}`. For standard properties
+like `displayName`, `mail`, `mailNickname` this works out of the box.
+
+To use an [Azure AD directory schema extension](https://learn.microsoft.com/en-us/graph/extensibility-overview)
+as one of those fields, Microsoft Graph requires the property to be referenced by its fully-qualified name
+`extension_<appIdWithoutDashes>_<name>`. There are two equivalent ways to configure this:
+
+1. **Put the full name into `authentication.xml`** — works without any extra job parameters, but requires
+   the same name on the JWT side too (which usually means setting up an Azure claims mapping policy).
+2. **Keep the bare name in `authentication.xml` and let the job expand it.** Set the following two job
+   parameters and the synchronizer will rewrite the listed mapping fields to
+   `extension_<appIdWithoutDashes>_<name>` before talking to Graph:
+
+   - **`extensionAppId`**: AAD application (client) ID owning the directory schema extension(s). Dashes
+     are stripped automatically when building the Graph property name.
+   - **`extensionFields`**: comma-separated list of mapping fields to expand — any combination of `id`,
+     `name`, `email`. When omitted but `extensionAppId` is set, defaults to `id`.
+
+Values that already start with `extension_` or that contain `/` (nested property paths such as
+`onPremisesExtensionAttributes/extensionAttribute1`) are passed through unchanged, so you can mix
+expanded and verbatim entries freely.
+
+**Example.** With this job configuration:
+
+```xml
+<extensionAppId>abc123de-f456-7890-abcd-ef1234567890</extensionAppId>
+<extensionFields>id,email</extensionFields>
+```
+
+and this `authentication.xml` mapping:
+
+```xml
+<mapping>
+    <id>mycustomid</id>          <!-- bare → extension_abc123def4567890abcdef1234567890_mycustomid -->
+    <name>displayName</name>     <!-- standard property, untouched -->
+    <email>myworkmail</email>    <!-- bare → extension_abc123def4567890abcdef1234567890_myworkmail -->
+</mapping>
+```
+
+the synchronizer will query Graph with `$select=extension_abc123def4567890abcdef1234567890_mycustomid,displayName,extension_abc123def4567890abcdef1234567890_myworkmail`
+when fetching each user, and use the resolved `extension_..._mycustomid` value as the Polarion user identifier.
+
+> [!NOTE]
+> Members of the AAD group are first listed via `/groups/{id}/members` to obtain their AAD object IDs,
+> and then each user is fetched individually via `/users/{aadObjectId}`. The per-user call is required
+> because the `/groups/{id}/members` endpoint returns directory objects that strip extension attributes
+> via `$select`.
 
 #### Group Synchronization
 

--- a/aad-sync-it.properties.example
+++ b/aad-sync-it.properties.example
@@ -1,0 +1,30 @@
+сдел# Template for the integration-test profile (GraphConnectorIT).
+#
+# Copy this file to `aad-sync-it.properties` (same directory) and fill in real values.
+# The real file is gitignored — never commit secrets.
+#
+# Run with:
+#   mvn test -P integration-test
+#
+# Lookup order for every key: env var (AAD_SYNC_IT_*) → JVM system property → this file → default.
+
+# --- Required ---
+tenantId=00000000-0000-0000-0000-000000000000
+clientId=00000000-0000-0000-0000-000000000000
+clientSecret=replace-me
+groupPrefix=TEST_AAD_SYNC_
+
+# AAD application id that owns the directory schema extensions. Empty by default.
+#extensionAppId=00000000-0000-0000-0000-000000000000
+
+# Comma-separated mapping field keys to expand. Empty by default.
+#extensionFields=id,name,email
+
+# Bare attribute names the synchronizer reads from authentication.xml mapping.
+#mappingId=mycustomid
+#mappingName=displayName
+#mappingEmail=mail
+
+# Optional sanity check — when set, the test asserts this UPN is among the resolved members
+# of the first matching group.
+#expectedUpn=user@example.com

--- a/aad-sync-it.properties.example
+++ b/aad-sync-it.properties.example
@@ -1,4 +1,4 @@
-сдел# Template for the integration-test profile (GraphConnectorIT).
+# Template for the integration-test profile (GraphConnectorIT).
 #
 # Copy this file to `aad-sync-it.properties` (same directory) and fill in real values.
 # The real file is gitignored — never commit secrets.

--- a/pom.xml
+++ b/pom.xml
@@ -230,9 +230,9 @@
             Activated explicitly via `mvn test -P integration-test`. The default `mvn test` run
             does NOT pick up `*IT.java` files because surefire only matches the standard
             *Test/Test*/*Tests/*TestCase patterns, so IT classes stay dormant unless this profile
-            is on. Each IT class is additionally guarded by @EnabledIfEnvironmentVariable, so even
-            with the profile active the tests will skip themselves cleanly when the required
-            secrets are missing.
+            is on. Each IT class is additionally guarded by JUnit @EnabledIf("isConfigured"),
+            so even with the profile active the tests will skip themselves cleanly when the
+            required secrets are missing.
 
             Required env vars (see GraphConnectorIT javadoc for the full list and defaults):
               AAD_SYNC_IT_TENANT_ID

--- a/pom.xml
+++ b/pom.xml
@@ -222,4 +222,49 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!--
+            Manual integration tests against a real Microsoft Entra ID tenant.
+
+            Activated explicitly via `mvn test -P integration-test`. The default `mvn test` run
+            does NOT pick up `*IT.java` files because surefire only matches the standard
+            *Test/Test*/*Tests/*TestCase patterns, so IT classes stay dormant unless this profile
+            is on. Each IT class is additionally guarded by @EnabledIfEnvironmentVariable, so even
+            with the profile active the tests will skip themselves cleanly when the required
+            secrets are missing.
+
+            Required env vars (see GraphConnectorIT javadoc for the full list and defaults):
+              AAD_SYNC_IT_TENANT_ID
+              AAD_SYNC_IT_CLIENT_ID
+              AAD_SYNC_IT_CLIENT_SECRET
+              AAD_SYNC_IT_GROUP_PREFIX
+        -->
+        <profile>
+            <id>integration-test</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/*IT.java</include>
+                            </includes>
+                            <!--
+                                Run only IT classes in this profile, do not duplicate the unit
+                                test run. Override the default *Test patterns explicitly.
+                            -->
+                            <excludes>
+                                <exclude>**/*Test.java</exclude>
+                                <exclude>**/Test*.java</exclude>
+                                <exclude>**/*Tests.java</exclude>
+                                <exclude>**/*TestCase.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnit.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnit.java
@@ -10,6 +10,10 @@ public interface AADUserSynchronizationJobUnit extends IJobUnit {
 
     void setAuthenticationProviderId(String authenticationProviderId);
 
+    void setExtensionAppId(String extensionAppId);
+
+    void setExtensionFields(String extensionFields);
+
     void setGroupPrefix(String groupPrefix);
 
     void setWhitelist(Whitelist whitelist);

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactory.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactory.java
@@ -14,6 +14,8 @@ import java.util.Map;
 public class AADUserSynchronizationJobUnitFactory implements IJobUnitFactory {
 
     public static final String AUTHENTICATION_PROVIDER_ID = "authenticationProviderId";
+    public static final String EXTENSION_APP_ID = "extensionAppId";
+    public static final String EXTENSION_FIELDS = "extensionFields";
     public static final String GROUP_PREFIX = "groupPrefix";
     public static final String WHITELIST = "whitelist";
     public static final String BLACKLIST = "blacklist";
@@ -40,6 +42,18 @@ public class AADUserSynchronizationJobUnitFactory implements IJobUnitFactory {
                 AUTHENTICATION_PROVIDER_ID,
                 "Authentication Provider ID",
                 stringType));
+
+        desc.addParameter(new SimpleJobParameter(
+                desc.getRootParameterGroup(),
+                EXTENSION_APP_ID,
+                "AAD application (client) ID owning the directory schema extension(s) referenced from authentication.xml. When set together with extensionFields, the listed mapping fields are automatically expanded to extension_<appIdWithoutDashes>_<name> when querying Microsoft Graph.",
+                stringType).setRequired(false));
+
+        desc.addParameter(new SimpleJobParameter(
+                desc.getRootParameterGroup(),
+                EXTENSION_FIELDS,
+                "Comma-separated list of authentication.xml mapping fields to treat as directory schema extensions: any combination of 'id', 'name', 'email'. Each listed field is auto-expanded with extensionAppId. Defaults to 'id' when only extensionAppId is set.",
+                stringType).setRequired(false));
 
         desc.addParameter(new SimpleJobParameter(
                 desc.getRootParameterGroup(),

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnit.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnit.java
@@ -37,6 +37,8 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
     private final IGraphConnector externalGraphConnector;
 
     private String authenticationProviderId;
+    private String extensionAppId;
+    private String extensionFields;
     private IOAuth2SecurityConfiguration authenticationProviderConfiguration;
     private String groupPrefix;
     private Whitelist whitelist;
@@ -70,72 +72,78 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
                 "|                    REAL RUN                   |");
         JobLogger.getInstance().separator();
 
-        JobLogger.getInstance().separator();
-        IGraphService graphService = buildGraphService();
-        JobLogger.getInstance().separator();
-
-        JobLogger.getInstance().separator();
-        final List<String> allMemberIds = new ArrayList<>(graphService.getAadMemberIds(groupPrefix));
-        JobLogger.getInstance().separator();
-
-        JobLogger.getInstance().separator();
-        JobLogger.getInstance().log("Filtering members...");
-        MemberFilter memberFilter = new MemberFilter(whitelist, blacklist);
-        final List<String> filteredMemberIds = memberFilter.filterMembers(allMemberIds);
-        JobLogger.getInstance().separator();
-
-        if (checkLastSynchronization) {
+        GraphConnector ownGraphConnector = null;
+        try {
             JobLogger.getInstance().separator();
-            graphService.checkLastSynchronization();
+            IGraphConnector graphConnector;
+            if (externalGraphConnector != null) {
+                graphConnector = externalGraphConnector;
+                JobLogger.getInstance().log("Using external graph connector: " + externalGraphConnector.getClass());
+            } else {
+                String graphApiToken = new OAuth2Client().getToken(authenticationProviderConfiguration);
+                ownGraphConnector = new GraphConnector(authenticationProviderConfiguration, graphApiToken, extensionAppId, extensionFields);
+                graphConnector = ownGraphConnector;
+            }
+            IGraphService graphService = new GraphService(graphConnector);
             JobLogger.getInstance().separator();
+
+            JobLogger.getInstance().separator();
+            final List<String> allMemberIds = new ArrayList<>(graphService.getAadMemberIds(groupPrefix));
+            JobLogger.getInstance().separator();
+
+            JobLogger.getInstance().separator();
+            JobLogger.getInstance().log("Filtering members...");
+            MemberFilter memberFilter = new MemberFilter(whitelist, blacklist);
+            final List<String> filteredMemberIds = memberFilter.filterMembers(allMemberIds);
+            JobLogger.getInstance().separator();
+
+            if (checkLastSynchronization) {
+                JobLogger.getInstance().separator();
+                graphService.checkLastSynchronization();
+                JobLogger.getInstance().separator();
+            }
+
+            JobLogger.getInstance().separator();
+            IPolarionService polarionService = buildPolarionService(filteredMemberIds);
+            JobLogger.getInstance().separator();
+
+            JobLogger.getInstance().separator();
+            JobLogger.getInstance().log("Checking for duplicated users in Polarion...");
+            TransactionalExecutor.executeSafelyInReadOnlyTransaction(transaction -> {
+                        polarionService.checkDuplicatedPolarionUsers();
+                        return null;
+                    }
+            );
+            JobLogger.getInstance().separator();
+
+            JobLogger.getInstance().separator();
+            JobLogger.getInstance().log("Removing users in Polarion which are not in AzureAD anymore...");
+            TransactionalExecutor.executeInWriteTransaction(transaction -> {
+                        polarionService.deletePolarionUsers(filteredMemberIds);
+                        return null;
+                    }
+            );
+            JobLogger.getInstance().separator();
+
+            JobLogger.getInstance().separator();
+            JobLogger.getInstance().log("Creating users in Polarion which have been added into AzureAD...");
+            TransactionalExecutor.executeInWriteTransaction(transaction -> {
+                        polarionService.createPolarionUsers(filteredMemberIds);
+                        return null;
+                    }
+            );
+            JobLogger.getInstance().separator();
+
+            return getStatusOK(JobLogger.getInstance().getLog());
+        } finally {
+            if (ownGraphConnector != null) {
+                try {
+                    ownGraphConnector.close();
+                } catch (RuntimeException e) {
+                    JobLogger.getInstance().log("Failed to close Graph HTTP client: %s", e.getMessage());
+                }
+            }
         }
-
-        JobLogger.getInstance().separator();
-        IPolarionService polarionService = buildPolarionService(filteredMemberIds);
-        JobLogger.getInstance().separator();
-
-        JobLogger.getInstance().separator();
-        JobLogger.getInstance().log("Checking for duplicated users in Polarion...");
-        TransactionalExecutor.executeSafelyInReadOnlyTransaction(transaction -> {
-                    polarionService.checkDuplicatedPolarionUsers();
-                    return null;
-                }
-        );
-        JobLogger.getInstance().separator();
-
-        JobLogger.getInstance().separator();
-        JobLogger.getInstance().log("Removing users in Polarion which are not in AzureAD anymore...");
-        TransactionalExecutor.executeInWriteTransaction(transaction -> {
-                    polarionService.deletePolarionUsers(filteredMemberIds);
-                    return null;
-                }
-        );
-        JobLogger.getInstance().separator();
-
-        JobLogger.getInstance().separator();
-        JobLogger.getInstance().log("Creating users in Polarion which have been added into AzureAD...");
-        TransactionalExecutor.executeInWriteTransaction(transaction -> {
-                    polarionService.createPolarionUsers(filteredMemberIds);
-                    return null;
-                }
-        );
-        JobLogger.getInstance().separator();
-
-        return getStatusOK(JobLogger.getInstance().getLog());
-    }
-
-    @NotNull
-    private IGraphService buildGraphService() {
-        IGraphConnector graphConnector;
-        if (externalGraphConnector != null) {
-            graphConnector = externalGraphConnector;
-            JobLogger.getInstance().log("Using external graph connector: " + externalGraphConnector.getClass());
-        } else {
-            String graphApiToken = new OAuth2Client().getToken(authenticationProviderConfiguration);
-            graphConnector = new GraphConnector(authenticationProviderConfiguration, graphApiToken);
-        }
-
-        return new GraphService(graphConnector);
     }
 
     @NotNull
@@ -184,6 +192,16 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
     @Override
     public void setAuthenticationProviderId(String authenticationProviderId) {
         this.authenticationProviderId = authenticationProviderId;
+    }
+
+    @Override
+    public void setExtensionAppId(String extensionAppId) {
+        this.extensionAppId = extensionAppId;
+    }
+
+    @Override
+    public void setExtensionFields(String extensionFields) {
+        this.extensionFields = extensionFields;
     }
 
     @Override

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnit.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnit.java
@@ -72,78 +72,70 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
                 "|                    REAL RUN                   |");
         JobLogger.getInstance().separator();
 
-        GraphConnector ownGraphConnector = null;
-        try {
-            JobLogger.getInstance().separator();
-            IGraphConnector graphConnector;
-            if (externalGraphConnector != null) {
-                graphConnector = externalGraphConnector;
-                JobLogger.getInstance().log("Using external graph connector: " + externalGraphConnector.getClass());
-            } else {
-                String graphApiToken = new OAuth2Client().getToken(authenticationProviderConfiguration);
-                ownGraphConnector = new GraphConnector(authenticationProviderConfiguration, graphApiToken, extensionAppId, extensionFields);
-                graphConnector = ownGraphConnector;
-            }
-            IGraphService graphService = new GraphService(graphConnector);
-            JobLogger.getInstance().separator();
-
-            JobLogger.getInstance().separator();
-            final List<String> allMemberIds = new ArrayList<>(graphService.getAadMemberIds(groupPrefix));
-            JobLogger.getInstance().separator();
-
-            JobLogger.getInstance().separator();
-            JobLogger.getInstance().log("Filtering members...");
-            MemberFilter memberFilter = new MemberFilter(whitelist, blacklist);
-            final List<String> filteredMemberIds = memberFilter.filterMembers(allMemberIds);
-            JobLogger.getInstance().separator();
-
-            if (checkLastSynchronization) {
-                JobLogger.getInstance().separator();
-                graphService.checkLastSynchronization();
-                JobLogger.getInstance().separator();
-            }
-
-            JobLogger.getInstance().separator();
-            IPolarionService polarionService = buildPolarionService(filteredMemberIds);
-            JobLogger.getInstance().separator();
-
-            JobLogger.getInstance().separator();
-            JobLogger.getInstance().log("Checking for duplicated users in Polarion...");
-            TransactionalExecutor.executeSafelyInReadOnlyTransaction(transaction -> {
-                        polarionService.checkDuplicatedPolarionUsers();
-                        return null;
-                    }
-            );
-            JobLogger.getInstance().separator();
-
-            JobLogger.getInstance().separator();
-            JobLogger.getInstance().log("Removing users in Polarion which are not in AzureAD anymore...");
-            TransactionalExecutor.executeInWriteTransaction(transaction -> {
-                        polarionService.deletePolarionUsers(filteredMemberIds);
-                        return null;
-                    }
-            );
-            JobLogger.getInstance().separator();
-
-            JobLogger.getInstance().separator();
-            JobLogger.getInstance().log("Creating users in Polarion which have been added into AzureAD...");
-            TransactionalExecutor.executeInWriteTransaction(transaction -> {
-                        polarionService.createPolarionUsers(filteredMemberIds);
-                        return null;
-                    }
-            );
-            JobLogger.getInstance().separator();
-
-            return getStatusOK(JobLogger.getInstance().getLog());
-        } finally {
-            if (ownGraphConnector != null) {
-                try {
-                    ownGraphConnector.close();
-                } catch (RuntimeException e) {
-                    JobLogger.getInstance().log("Failed to close Graph HTTP client: %s", e.getMessage());
-                }
-            }
+        if (externalGraphConnector != null) {
+            JobLogger.getInstance().log("Using external graph connector: " + externalGraphConnector.getClass());
+            return runWithGraphConnector(externalGraphConnector);
         }
+
+        String graphApiToken = new OAuth2Client().getToken(authenticationProviderConfiguration);
+        try (GraphConnector ownGraphConnector = new GraphConnector(authenticationProviderConfiguration, graphApiToken, extensionAppId, extensionFields)) {
+            return runWithGraphConnector(ownGraphConnector);
+        }
+    }
+
+    private IJobStatus runWithGraphConnector(IGraphConnector graphConnector) {
+        JobLogger.getInstance().separator();
+        IGraphService graphService = new GraphService(graphConnector);
+        JobLogger.getInstance().separator();
+
+        JobLogger.getInstance().separator();
+        final List<String> allMemberIds = new ArrayList<>(graphService.getAadMemberIds(groupPrefix));
+        JobLogger.getInstance().separator();
+
+        JobLogger.getInstance().separator();
+        JobLogger.getInstance().log("Filtering members...");
+        MemberFilter memberFilter = new MemberFilter(whitelist, blacklist);
+        final List<String> filteredMemberIds = memberFilter.filterMembers(allMemberIds);
+        JobLogger.getInstance().separator();
+
+        if (checkLastSynchronization) {
+            JobLogger.getInstance().separator();
+            graphService.checkLastSynchronization();
+            JobLogger.getInstance().separator();
+        }
+
+        JobLogger.getInstance().separator();
+        IPolarionService polarionService = buildPolarionService(filteredMemberIds);
+        JobLogger.getInstance().separator();
+
+        JobLogger.getInstance().separator();
+        JobLogger.getInstance().log("Checking for duplicated users in Polarion...");
+        TransactionalExecutor.executeSafelyInReadOnlyTransaction(transaction -> {
+                    polarionService.checkDuplicatedPolarionUsers();
+                    return null;
+                }
+        );
+        JobLogger.getInstance().separator();
+
+        JobLogger.getInstance().separator();
+        JobLogger.getInstance().log("Removing users in Polarion which are not in AzureAD anymore...");
+        TransactionalExecutor.executeInWriteTransaction(transaction -> {
+                    polarionService.deletePolarionUsers(filteredMemberIds);
+                    return null;
+                }
+        );
+        JobLogger.getInstance().separator();
+
+        JobLogger.getInstance().separator();
+        JobLogger.getInstance().log("Creating users in Polarion which have been added into AzureAD...");
+        TransactionalExecutor.executeInWriteTransaction(transaction -> {
+                    polarionService.createPolarionUsers(filteredMemberIds);
+                    return null;
+                }
+        );
+        JobLogger.getInstance().separator();
+
+        return getStatusOK(JobLogger.getInstance().getLog());
     }
 
     @NotNull

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
@@ -9,9 +9,11 @@ import ch.sbb.polarion.extension.aad.synchronizer.model.Member;
 import ch.sbb.polarion.extension.aad.synchronizer.model.MemberResponseWrapper;
 import ch.sbb.polarion.extension.aad.synchronizer.model.OrganizationData;
 import ch.sbb.polarion.extension.aad.synchronizer.model.OrganizationDataWrapper;
+import ch.sbb.polarion.extension.aad.synchronizer.utils.JsonListParser;
 import ch.sbb.polarion.extension.generic.util.JobLogger;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.polarion.core.config.IOAuth2SecurityConfiguration;
 import org.jetbrains.annotations.VisibleForTesting;
@@ -25,32 +27,92 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-public class GraphConnector implements IGraphConnector {
+public class GraphConnector implements IGraphConnector, AutoCloseable {
 
     private static final String HEADER = "Bearer ";
     private static final String SENT_REQUEST_MESSAGE = "Sent request: %s";
     private static final int JSON_INDENT_FACTOR = 4;
     private static final String GRAPH_MICROSOFT_URL = "https://graph.microsoft.com";
 
+    /**
+     * Maximum number of times a single Microsoft Graph request will be retried after receiving a
+     * transient throttling/availability response. The total number of attempts is therefore
+     * {@code MAX_RETRIES + 1}.
+     */
+    private static final int MAX_RETRIES = 5;
+    private static final long DEFAULT_BACKOFF_BASE_MILLIS = 1_000L;
+    private static final long MAX_BACKOFF_MILLIS = 60_000L;
+    /**
+     * HTTP statuses that Microsoft Graph documents as transient and safe to retry: 429 Too Many
+     * Requests (throttling), 503 Service Unavailable, 504 Gateway Timeout. All other non-200 codes
+     * are surfaced as {@link InvalidGraphResponseException} on the first occurrence.
+     */
+    private static final Set<Integer> RETRYABLE_STATUSES = Set.of(429, 503, 504);
+
     private final IOAuth2SecurityConfiguration authenticationProviderConfiguration;
     private final String token;
     private final String graphUrl;
+    private final String extensionAppId;
+    private final Set<String> extensionFields;
     private final UrlBuilder urlBuilder;
     private final ObjectMapper objectMapper = prepareObjectMapper();
+    /**
+     * One JAX-RS {@link Client} per connector instance, reused for every Graph request. Avoids the
+     * per-call TLS handshake that dominated latency on groups with hundreds of members. The
+     * underlying connection pool is released by {@link #close()} at the end of the job.
+     */
+    private final Client httpClient;
 
     public GraphConnector(IOAuth2SecurityConfiguration authenticationProviderConfiguration, String token) {
-        this(authenticationProviderConfiguration, token, GRAPH_MICROSOFT_URL);
+        this(authenticationProviderConfiguration, token, null, null, GRAPH_MICROSOFT_URL);
+    }
+
+    public GraphConnector(IOAuth2SecurityConfiguration authenticationProviderConfiguration, String token, String extensionAppId, String extensionFields) {
+        this(authenticationProviderConfiguration, token, extensionAppId, extensionFields, GRAPH_MICROSOFT_URL);
     }
 
     @VisibleForTesting
-    GraphConnector(IOAuth2SecurityConfiguration authenticationProviderConfiguration, String token, String graphUrl) {
+    GraphConnector(IOAuth2SecurityConfiguration authenticationProviderConfiguration, String token, String extensionAppId, String extensionFields, String graphUrl) {
         this.authenticationProviderConfiguration = authenticationProviderConfiguration;
         this.token = token;
+        this.extensionAppId = extensionAppId;
+        this.extensionFields = parseExtensionFields(extensionFields, extensionAppId);
         this.urlBuilder = new UrlBuilder();
         this.graphUrl = graphUrl;
+        this.httpClient = ClientBuilder.newClient();
+    }
+
+    /**
+     * Releases the underlying JAX-RS HTTP client and its connection pool. Safe to call multiple
+     * times. Should be called once at the end of a synchronization run.
+     */
+    @Override
+    public void close() {
+        httpClient.close();
+    }
+
+    /**
+     * Parses the comma-separated {@code extensionFields} job parameter into a set of mapping field
+     * keys ({@code id}, {@code name}, {@code email}). When unset but {@code extensionAppId} is
+     * configured, defaults to {@code {id}} for backward compatibility — the original use case being
+     * a custom identifier attribute.
+     */
+    private static Set<String> parseExtensionFields(String csv, String extensionAppId) {
+        if (csv == null || csv.isBlank()) {
+            return (extensionAppId == null || extensionAppId.isBlank())
+                    ? Set.of()
+                    : Set.of(MemberResponseWrapper.ID);
+        }
+        return Arrays.stream(csv.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     private ObjectMapper prepareObjectMapper() {
@@ -72,30 +134,113 @@ public class GraphConnector implements IGraphConnector {
 
     @Override
     public List<Member> getMembers(String key) {
-        String id = authenticationProviderConfiguration.mapping().id();
-        String name = authenticationProviderConfiguration.mapping().name();
-        String email = authenticationProviderConfiguration.mapping().email();
+        String idField = expandIfMarked(MemberResponseWrapper.ID, authenticationProviderConfiguration.mapping().id());
+        String nameField = expandIfMarked(MemberResponseWrapper.NAME, authenticationProviderConfiguration.mapping().name());
+        String emailField = expandIfMarked(MemberResponseWrapper.EMAIL, authenticationProviderConfiguration.mapping().email());
 
-        Map<String, String> fieldsMapping = Map.ofEntries(
-                Map.entry(MemberResponseWrapper.ID, id),
-                Map.entry(MemberResponseWrapper.NAME, name),
-                Map.entry(MemberResponseWrapper.EMAIL, email)
+        List<String> aadObjectIds = fetchGroupMemberObjectIds(key);
+
+        Map<String, String> userFieldsMapping = Map.ofEntries(
+                Map.entry(MemberResponseWrapper.ID, idField),
+                Map.entry(MemberResponseWrapper.NAME, nameField),
+                Map.entry(MemberResponseWrapper.EMAIL, emailField)
         );
+        String selectValue = "%s,%s,%s".formatted(idField, nameField, emailField);
 
-        String searchEndpoint = String.format("%s/members", key);
-        String url = urlBuilder.build(graphUrl, GraphOption.GROUPS, searchEndpoint);
-        String selectValue = "%s,%s,%s".formatted(id, name, email);
-        String searchResult = fetchMSGraphApi(url, "$select", selectValue, String.class);
-        MemberResponseWrapper memberResponseWrapper = MemberResponseWrapper.fromJsonList(searchResult, fieldsMapping);
-
-        List<Member> members = new ArrayList<>(memberResponseWrapper.getValue());
-        while (memberResponseWrapper.getNextLink() != null) {
-            searchResult = fetchMSGraphApi(memberResponseWrapper.getNextLink(), null, null, String.class);
-            memberResponseWrapper = MemberResponseWrapper.fromJsonList(searchResult, fieldsMapping);
-            members.addAll(memberResponseWrapper.getValue());
+        List<Member> members = new ArrayList<>(aadObjectIds.size());
+        for (String aadObjectId : aadObjectIds) {
+            members.add(fetchUser(aadObjectId, selectValue, userFieldsMapping));
         }
-
         return members;
+    }
+
+    private static final String GRAPH_USER_TYPE = "#microsoft.graph.user";
+
+    private List<String> fetchGroupMemberObjectIds(String key) {
+        String url = urlBuilder.build(graphUrl, GraphOption.GROUPS, String.format("%s/members", key));
+        String body = fetchMSGraphApi(url, "$select", "id", String.class);
+
+        List<String> ids = new ArrayList<>();
+        String nextLink = collectUserMemberIds(body, ids);
+        while (nextLink != null) {
+            body = fetchMSGraphApi(nextLink, null, null, String.class);
+            nextLink = collectUserMemberIds(body, ids);
+        }
+        return ids;
+    }
+
+    /**
+     * Walks one page of a {@code /groups/{id}/members} response, collecting object ids of
+     * members whose {@code @odata.type} is {@value #GRAPH_USER_TYPE}. Members of other directory
+     * object types (nested groups, service principals, devices, organizational contacts) are
+     * skipped — propagating their ids would cause {@link #fetchUser(String, String, java.util.Map)}
+     * to hit {@code /users/{id}} and get 404, blowing up the entire synchronization job.
+     *
+     * @return the {@code @odata.nextLink} for cursor-based pagination, or {@code null} when there
+     *         are no more pages.
+     */
+    private String collectUserMemberIds(String body, List<String> sink) {
+        try {
+            JsonNode root = objectMapper.readTree(body);
+            JsonNode value = root.get(JsonListParser.VALUE);
+            if (value != null && value.isArray()) {
+                for (JsonNode item : value) {
+                    JsonNode type = item.get("@odata.type");
+                    if (type == null || !GRAPH_USER_TYPE.equals(type.asText())) {
+                        continue;
+                    }
+                    JsonNode id = item.get("id");
+                    if (id != null && !id.isNull()) {
+                        sink.add(id.asText());
+                    }
+                }
+            }
+            JsonNode nextLink = root.get(JsonListParser.NEXT_LINK);
+            return (nextLink != null && !nextLink.isNull()) ? nextLink.asText() : null;
+        } catch (JsonProcessingException e) {
+            throw new ResponseParsingException(e);
+        }
+    }
+
+    private Member fetchUser(String aadObjectId, String selectValue, Map<String, String> fieldsMapping) {
+        String url = urlBuilder.build(graphUrl, GraphOption.USERS, aadObjectId);
+        String body = fetchMSGraphApi(url, "$select", selectValue, String.class);
+        return JsonListParser.parseObject(body, fieldsMapping, Member.class);
+    }
+
+    /**
+     * Returns the configured value, expanded to a directory schema extension property name when the
+     * given mapping field key (one of {@code id}, {@code name}, {@code email}) is listed in
+     * {@code extensionFields}. When the field is not marked as an extension, the value is used as-is.
+     */
+    @VisibleForTesting
+    String expandIfMarked(String fieldKey, String fieldValue) {
+        if (!extensionFields.contains(fieldKey)) {
+            return fieldValue;
+        }
+        return expandExtensionAttribute(fieldValue);
+    }
+
+    /**
+     * If {@code extensionAppId} is configured, expands a bare custom attribute name into the
+     * fully-qualified Microsoft Graph directory schema extension property name
+     * {@code extension_<appIdWithoutDashes>_<name>}. Leaves the value untouched when:
+     * <ul>
+     *     <li>no {@code extensionAppId} is configured;</li>
+     *     <li>the value already starts with {@code extension_} (already a full extension name);</li>
+     *     <li>the value contains a slash (a nested property path such as
+     *         {@code onPremisesExtensionAttributes/extensionAttribute1}).</li>
+     * </ul>
+     */
+    @VisibleForTesting
+    String expandExtensionAttribute(String fieldName) {
+        if (extensionAppId == null || extensionAppId.isBlank()
+                || fieldName == null
+                || fieldName.startsWith("extension_")
+                || fieldName.contains("/")) {
+            return fieldName;
+        }
+        return "extension_" + extensionAppId.replace("-", "") + "_" + fieldName;
     }
 
     @Override
@@ -110,14 +255,13 @@ public class GraphConnector implements IGraphConnector {
 
     @SuppressWarnings("unchecked")
     private <T> T fetchMSGraphApi(String url, String queryParamName, String queryParamValue, Class<T> targetClass) {
-        Client client = null;
-        try {
-            client = ClientBuilder.newClient();
-            WebTarget webTarget = client.target(url);
-            if (queryParamName != null && queryParamValue != null) {
-                webTarget = webTarget.queryParam(queryParamName, queryParamValue);
-            }
+        WebTarget webTarget = httpClient.target(url);
+        if (queryParamName != null && queryParamValue != null) {
+            webTarget = webTarget.queryParam(queryParamName, queryParamValue);
+        }
 
+        int attempt = 0;
+        while (true) {
             try (Response response = webTarget.request(MediaType.APPLICATION_JSON)
                     .header(HttpHeaders.AUTHORIZATION, HEADER + token)
                     .get()) {
@@ -125,7 +269,8 @@ public class GraphConnector implements IGraphConnector {
                 JobLogger.getInstance().log(SENT_REQUEST_MESSAGE, webTarget.getUri());
                 JobLogger.getInstance().log(getResponseStatusLine(response));
 
-                if (response.getStatus() == Response.Status.OK.getStatusCode()) {
+                int status = response.getStatus();
+                if (status == Response.Status.OK.getStatusCode()) {
                     String responseContent = getResponseContent(response);
                     if (targetClass == String.class) {
                         return (T) responseContent;
@@ -135,18 +280,58 @@ public class GraphConnector implements IGraphConnector {
                     } catch (JsonProcessingException e) {
                         throw new ResponseParsingException(e);
                     }
-                } else {
-                    if (response.getStatus() == Response.Status.UNAUTHORIZED.getStatusCode()) {
-                        throw new InvalidGraphResponseException("Microsoft Graph token expired");
-                    } else {
-                        throw new InvalidGraphResponseException("Could not get proper response from Microsoft Graph");
-                    }
                 }
+
+                if (RETRYABLE_STATUSES.contains(status) && attempt < MAX_RETRIES) {
+                    long sleepMillis = computeBackoffMillis(response, attempt);
+                    JobLogger.getInstance().log(
+                            "Got HTTP %d from Microsoft Graph; retrying in %d ms (attempt %d/%d)",
+                            status, sleepMillis, attempt + 1, MAX_RETRIES);
+                    sleepInterruptibly(sleepMillis);
+                    attempt++;
+                    continue;
+                }
+
+                if (status == Response.Status.UNAUTHORIZED.getStatusCode()) {
+                    throw new InvalidGraphResponseException("Microsoft Graph token expired");
+                }
+                throw new InvalidGraphResponseException("Could not get proper response from Microsoft Graph");
             }
-        } finally {
-            if (client != null) {
-                client.close();
+        }
+    }
+
+    /**
+     * Computes how long to wait before retrying a throttled/unavailable Graph response. Honours
+     * the {@code Retry-After} header when present and parsable as an integer number of seconds
+     * (the format Microsoft Graph uses for throttling). Otherwise falls back to exponential
+     * backoff: 1s, 2s, 4s, 8s, 16s — capped at {@value #MAX_BACKOFF_MILLIS} ms.
+     */
+    private static long computeBackoffMillis(Response response, int attempt) {
+        String retryAfter = response.getHeaderString(HttpHeaders.RETRY_AFTER);
+        if (retryAfter != null) {
+            try {
+                long seconds = Long.parseLong(retryAfter.trim());
+                if (seconds >= 0) {
+                    return Math.min(seconds * 1_000L, MAX_BACKOFF_MILLIS);
+                }
+            } catch (NumberFormatException ignored) {
+                // Retry-After can also be an HTTP-date; we don't parse that, fall through to
+                // exponential backoff so the retry still happens.
             }
+        }
+        long backoff = DEFAULT_BACKOFF_BASE_MILLIS << Math.min(attempt, 10);
+        return Math.min(backoff, MAX_BACKOFF_MILLIS);
+    }
+
+    private static void sleepInterruptibly(long millis) {
+        if (millis <= 0) {
+            return;
+        }
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new InvalidGraphResponseException("Interrupted while waiting to retry Microsoft Graph request");
         }
     }
 

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
@@ -138,6 +138,20 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
         return searchResult.getValue();
     }
 
+    /**
+     * Resolves all members of an AAD group through the configured field mapping.
+     *
+     * <p><b>Why two requests per member instead of one batch call</b>: the synchronizer used to
+     * read members in a single {@code /groups/{id}/members?$select=...} call, but that endpoint
+     * returns {@code directoryObject}s and {@code $select} silently drops directory schema
+     * extension properties on certain configurations — see issue #74. Switching to a per-user
+     * fetch via {@code /users/{aadObjectId}} guarantees the extension attributes come back
+     * populated and isolates the synchronizer from any future {@code /members} quirks (nested
+     * directory object types, mixed-tenant guests, multi-valued extensions). The cost is an
+     * extra {@code N} HTTPS calls per group: tolerable for the daily cron, mitigated by
+     * connection reuse via the per-connector {@link Client} and by retry/backoff handling on
+     * 429/503/504 in {@link #fetchMSGraphApi}.</p>
+     */
     @Override
     public List<Member> getMembers(String key) {
         String idField = expandIfMarked(MemberResponseWrapper.ID, authenticationProviderConfiguration.mapping().id());
@@ -326,7 +340,8 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
      * (the format Microsoft Graph uses for throttling). Otherwise falls back to exponential
      * backoff: 1s, 2s, 4s, 8s, 16s — capped at {@value #MAX_BACKOFF_MILLIS} ms.
      */
-    private static long computeBackoffMillis(Response response, int attempt) {
+    @VisibleForTesting
+    static long computeBackoffMillis(Response response, int attempt) {
         String retryAfter = response.getHeaderString(HttpHeaders.RETRY_AFTER);
         if (retryAfter != null) {
             try {

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
@@ -90,11 +90,17 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
 
     /**
      * Releases the underlying JAX-RS HTTP client and its connection pool. Safe to call multiple
-     * times. Should be called once at the end of a synchronization run.
+     * times. Should be called once at the end of a synchronization run. Any runtime exception
+     * raised by the underlying client is logged and swallowed — a cleanup failure must not mask
+     * the actual job result, and the JVM will reclaim the connection pool on shutdown anyway.
      */
     @Override
     public void close() {
-        httpClient.close();
+        try {
+            httpClient.close();
+        } catch (RuntimeException e) {
+            JobLogger.getInstance().log("Failed to close Graph HTTP client: %s", e.getMessage());
+        }
     }
 
     /**
@@ -253,7 +259,6 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
         return searchResult.getValue().get(0);
     }
 
-    @SuppressWarnings("unchecked")
     private <T> T fetchMSGraphApi(String url, String queryParamName, String queryParamValue, Class<T> targetClass) {
         WebTarget webTarget = httpClient.target(url);
         if (queryParamName != null && queryParamValue != null) {
@@ -271,33 +276,48 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
 
                 int status = response.getStatus();
                 if (status == Response.Status.OK.getStatusCode()) {
-                    String responseContent = getResponseContent(response);
-                    if (targetClass == String.class) {
-                        return (T) responseContent;
-                    }
-                    try {
-                        return objectMapper.readValue(responseContent, targetClass);
-                    } catch (JsonProcessingException e) {
-                        throw new ResponseParsingException(e);
-                    }
+                    return parseSuccessfulResponse(response, targetClass);
                 }
-
-                if (RETRYABLE_STATUSES.contains(status) && attempt < MAX_RETRIES) {
-                    long sleepMillis = computeBackoffMillis(response, attempt);
-                    JobLogger.getInstance().log(
-                            "Got HTTP %d from Microsoft Graph; retrying in %d ms (attempt %d/%d)",
-                            status, sleepMillis, attempt + 1, MAX_RETRIES);
-                    sleepInterruptibly(sleepMillis);
+                if (shouldRetry(status, attempt)) {
+                    waitBeforeRetry(response, status, attempt);
                     attempt++;
                     continue;
                 }
-
-                if (status == Response.Status.UNAUTHORIZED.getStatusCode()) {
-                    throw new InvalidGraphResponseException("Microsoft Graph token expired");
-                }
-                throw new InvalidGraphResponseException("Could not get proper response from Microsoft Graph");
+                throw mapErrorStatus(status);
             }
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T parseSuccessfulResponse(Response response, Class<T> targetClass) {
+        String responseContent = getResponseContent(response);
+        if (targetClass == String.class) {
+            return (T) responseContent;
+        }
+        try {
+            return objectMapper.readValue(responseContent, targetClass);
+        } catch (JsonProcessingException e) {
+            throw new ResponseParsingException(e);
+        }
+    }
+
+    private static boolean shouldRetry(int status, int attempt) {
+        return RETRYABLE_STATUSES.contains(status) && attempt < MAX_RETRIES;
+    }
+
+    private static void waitBeforeRetry(Response response, int status, int attempt) {
+        long sleepMillis = computeBackoffMillis(response, attempt);
+        JobLogger.getInstance().log(
+                "Got HTTP %d from Microsoft Graph; retrying in %d ms (attempt %d/%d)",
+                status, sleepMillis, attempt + 1, MAX_RETRIES);
+        sleepInterruptibly(sleepMillis);
+    }
+
+    private static InvalidGraphResponseException mapErrorStatus(int status) {
+        if (status == Response.Status.UNAUTHORIZED.getStatusCode()) {
+            return new InvalidGraphResponseException("Microsoft Graph token expired");
+        }
+        return new InvalidGraphResponseException("Could not get proper response from Microsoft Graph");
     }
 
     /**

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphOption.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphOption.java
@@ -1,5 +1,5 @@
 package ch.sbb.polarion.extension.aad.synchronizer.connector;
 
 public enum GraphOption {
-    GROUPS, ORGANIZATION
+    GROUPS, ORGANIZATION, USERS
 }

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/utils/JsonListParser.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/utils/JsonListParser.java
@@ -32,6 +32,13 @@ public class JsonListParser {
         return wrapper;
     }
 
+    @SneakyThrows
+    public @NotNull <E> E parseObject(@NotNull String json, @NotNull Map<String, String> fieldsMapping, @NotNull Class<E> elementClass) {
+        JsonNode rootNode = getObjectMapper().readTree(json);
+        Map<String, String> fieldData = parseFields(rootNode, fieldsMapping);
+        return getObjectMapper().convertValue(fieldData, elementClass);
+    }
+
     public @NotNull <W, E> W parseList(@NotNull JsonNode rootNode, @NotNull String containerName, @NotNull Map<String, String> fieldsMapping, Class<W> wrapperClass, Class<E> elementClass) {
         ObjectMapper objectMapper = getObjectMapper();
         List<E> items = new ArrayList<>();
@@ -56,15 +63,20 @@ public class JsonListParser {
     }
 
     private @Nullable String getFieldValue(@NotNull JsonNode node, @Nullable String fieldName) {
-        if (fieldName != null && node.has(fieldName)) {
-            JsonNode jsonNode = node.get(fieldName);
-            if (jsonNode.isNull()) {
-                return null;
-            }
-            return jsonNode.asText();
-        } else {
+        if (fieldName == null) {
             return null;
         }
+        JsonNode current = node;
+        for (String segment : fieldName.split("/")) {
+            if (current == null || !current.has(segment)) {
+                return null;
+            }
+            current = current.get(segment);
+        }
+        if (current == null || current.isNull()) {
+            return null;
+        }
+        return current.asText();
     }
 
     private ObjectMapper getObjectMapper() {

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/FakeOAuth2SecurityConfiguration.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/FakeOAuth2SecurityConfiguration.java
@@ -14,6 +14,21 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 public class FakeOAuth2SecurityConfiguration implements IOAuth2SecurityConfiguration {
+
+    private final String mappingId;
+    private final String mappingName;
+    private final String mappingEmail;
+
+    public FakeOAuth2SecurityConfiguration() {
+        this("mailNickname", "displayName", "mail");
+    }
+
+    public FakeOAuth2SecurityConfiguration(String mappingId, String mappingName, String mappingEmail) {
+        this.mappingId = mappingId;
+        this.mappingName = mappingName;
+        this.mappingEmail = mappingEmail;
+    }
+
     @Override
     public @NotNull String responseParser() {
         return "";
@@ -89,17 +104,17 @@ public class FakeOAuth2SecurityConfiguration implements IOAuth2SecurityConfigura
         return new IAuthProfileMappingConfiguration() {
             @Override
             public @NotNull String id() {
-                return "mailNickname";
+                return mappingId;
             }
 
             @Override
             public @NotNull String name() {
-                return "displayName";
+                return mappingName;
             }
 
             @Override
             public @NotNull String email() {
-                return "mail";
+                return mappingEmail;
             }
 
             @Override

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
@@ -20,6 +20,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 /**
  * Integration tests that talk to a real Microsoft Entra ID tenant. They are <strong>not</strong>
@@ -185,8 +186,8 @@ class GraphConnectorIT {
 
         assertThat(groups)
                 .as("at least one AAD group with prefix '%s' must exist for the IT to be meaningful", groupPrefix)
-                .isNotEmpty();
-        assertThat(groups).allSatisfy(group -> assertThat(group.getId()).isNotBlank());
+                .isNotEmpty()
+                .allSatisfy(group -> assertThat(group.getId()).isNotBlank());
     }
 
     @Test
@@ -209,18 +210,17 @@ class GraphConnectorIT {
                     + " email=" + valueOrNullMarker(member.getEmail()));
         }
 
-        assertThat(members)
-                .as("group '%s' should have at least one member resolvable through the configured mapping", firstGroup.getId())
-                .isNotEmpty();
-
         // Each member must have all three mapped fields resolved to non-null values. If any of
         // these come back null we are reproducing issue #74 — Graph silently returns empty user
         // objects when the $select asks for properties it does not understand.
-        assertThat(members).allSatisfy(member -> {
-            assertThat(member.getId()).as("member id must be resolved").isNotBlank();
-            assertThat(member.getName()).as("member name must be resolved").isNotBlank();
-            assertThat(member.getEmail()).as("member email must be resolved").isNotBlank();
-        });
+        assertThat(members)
+                .as("group '%s' should have at least one member resolvable through the configured mapping", firstGroup.getId())
+                .isNotEmpty()
+                .allSatisfy(member -> {
+                    assertThat(member.getId()).as("member id must be resolved").isNotBlank();
+                    assertThat(member.getName()).as("member name must be resolved").isNotBlank();
+                    assertThat(member.getEmail()).as("member email must be resolved").isNotBlank();
+                });
 
         String expectedUpn = lookup("AAD_SYNC_IT_EXPECTED_UPN", "expectedUpn", null);
         if (expectedUpn != null && !expectedUpn.isBlank()) {
@@ -261,9 +261,9 @@ class GraphConnectorIT {
 
         assertThat(ids)
                 .as("GraphService should return at least one resolved member id for prefix '%s'", groupPrefix)
-                .isNotEmpty();
-        assertThat(ids).doesNotContainNull();
-        assertThat(ids).allSatisfy(id -> assertThat(id).isNotBlank());
+                .isNotEmpty()
+                .doesNotContainNull()
+                .allSatisfy(id -> assertThat(id).isNotBlank());
     }
 
     /**
@@ -275,7 +275,9 @@ class GraphConnectorIT {
     void connectorCloseIsIdempotent() {
         GraphConnector throwaway = new GraphConnector(config, token, extensionAppId, extensionFields);
         throwaway.close();
-        throwaway.close();   // must not throw
+        assertThatNoException()
+                .as("a second close() on an already-closed connector must not throw")
+                .isThrownBy(throwaway::close);
     }
 
     private static void log(String line) {

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
@@ -29,9 +29,10 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
  * <ol>
  *     <li>The class name ends with {@code IT}, which surefire ignores by default
  *         (it only matches {@code *Test} / {@code Test*} / {@code *Tests} / {@code *TestCase}).</li>
- *     <li>The {@link EnabledIfEnvironmentVariable} guard skips every test unless the required
- *         environment variables are set, so even if the class is invoked from an IDE without
- *         configuration the suite stays green.</li>
+ *     <li>The {@link EnabledIf @EnabledIf("isConfigured")} guard skips every test unless the
+ *         required configuration is available (env var, system property, or properties file —
+ *         see below), so even if the class is invoked from an IDE without setup the suite stays
+ *         green.</li>
  * </ol>
  *
  * <h2>How to run</h2>

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
@@ -1,0 +1,391 @@
+package ch.sbb.polarion.extension.aad.synchronizer.connector;
+
+import ch.sbb.polarion.extension.aad.synchronizer.model.Group;
+import ch.sbb.polarion.extension.aad.synchronizer.model.Member;
+import ch.sbb.polarion.extension.aad.synchronizer.service.GraphService;
+import ch.sbb.polarion.extension.aad.synchronizer.utils.OAuth2Client;
+import org.apache.oltu.oauth2.client.OAuthClient;
+import org.apache.oltu.oauth2.client.URLConnectionClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests that talk to a real Microsoft Entra ID tenant. They are <strong>not</strong>
+ * picked up by the default {@code mvn test} run because:
+ *
+ * <ol>
+ *     <li>The class name ends with {@code IT}, which surefire ignores by default
+ *         (it only matches {@code *Test} / {@code Test*} / {@code *Tests} / {@code *TestCase}).</li>
+ *     <li>The {@link EnabledIfEnvironmentVariable} guard skips every test unless the required
+ *         environment variables are set, so even if the class is invoked from an IDE without
+ *         configuration the suite stays green.</li>
+ * </ol>
+ *
+ * <h2>How to run</h2>
+ *
+ * Activate the {@code integration-test} Maven profile and supply the secrets via either
+ * environment variables, JVM system properties, or a {@code .properties} file. Lookup order for
+ * every setting is: <strong>env var → JVM system property → properties file → built-in
+ * default</strong>. The first non-blank value wins. This lets you mix sources freely (e.g. keep
+ * the secret in the file and override the group prefix on the command line).
+ *
+ * <h3>Properties file</h3>
+ *
+ * <p>By default the suite looks for {@code aad-sync-it.properties} in the project root (the
+ * directory {@code mvn} runs from). The file is gitignored so secrets stay out of version
+ * control; an {@code aad-sync-it.properties.example} template is committed alongside it. Override
+ * the location with env var {@code AAD_SYNC_IT_CONFIG_FILE} or system property
+ * {@code aad-sync-it.config-file}. The file is plain Java {@link Properties} format with
+ * camelCase keys. Example:</p>
+ *
+ * <pre>{@code
+ * tenantId=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+ * clientId=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+ * clientSecret=...
+ * groupPrefix=TEST_AAD_SYNC_
+ * # Optional overrides — defaults are vanilla MS Graph user properties
+ * # extensionAppId=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+ * # extensionFields=id,name,email
+ * # mappingId=mycustomid
+ * # mappingName=displayName
+ * # mappingEmail=mail
+ * # expectedUpn=user@example.com
+ * }</pre>
+ *
+ * <p>Then run:</p>
+ *
+ * <pre>{@code
+ * mvn test -P integration-test
+ * }</pre>
+ *
+ * <h3>Environment variable equivalents</h3>
+ *
+ * <p>Each properties key has an equivalent uppercase env var with the {@code AAD_SYNC_IT_}
+ * prefix:</p>
+ *
+ * <ul>
+ *     <li>{@code tenantId} ↔ {@code AAD_SYNC_IT_TENANT_ID} — required</li>
+ *     <li>{@code clientId} ↔ {@code AAD_SYNC_IT_CLIENT_ID} — required</li>
+ *     <li>{@code clientSecret} ↔ {@code AAD_SYNC_IT_CLIENT_SECRET} — required</li>
+ *     <li>{@code groupPrefix} ↔ {@code AAD_SYNC_IT_GROUP_PREFIX} — required</li>
+ *     <li>{@code extensionAppId} ↔ {@code AAD_SYNC_IT_EXTENSION_APP_ID} — AAD application id
+ *         that owns the directory schema extensions. Empty by default. Set this together with
+ *         {@code extensionFields} when your test users carry custom extension attributes that
+ *         need to be expanded to {@code extension_<appIdNoDashes>_<name>}.</li>
+ *     <li>{@code extensionFields} ↔ {@code AAD_SYNC_IT_EXTENSION_FIELDS} — comma-separated
+ *         mapping field keys to expand. Empty by default — i.e. mapping fields are passed to
+ *         Graph as-is.</li>
+ *     <li>{@code mappingId} / {@code mappingName} / {@code mappingEmail} ↔
+ *         {@code AAD_SYNC_IT_MAPPING_ID} / {@code _NAME} / {@code _EMAIL} — bare attribute names
+ *         the synchronizer reads from {@code authentication.xml}. Default to the standard MS
+ *         Graph user properties {@code mailNickname} / {@code displayName} / {@code mail}, so
+ *         the IT works against any vanilla Entra group out of the box.</li>
+ *     <li>{@code expectedUpn} ↔ {@code AAD_SYNC_IT_EXPECTED_UPN} — when set, an additional
+ *         assertion verifies that this user is among the resolved members of the first matching
+ *         group.</li>
+ * </ul>
+ *
+ * <p>Each test issues real HTTPS calls against {@code login.microsoftonline.com} and
+ * {@code graph.microsoft.com}. Run cost is a handful of Graph requests per test plus one token
+ * acquisition; well within the application throttling envelope.</p>
+ */
+@EnabledIf("isConfigured")
+class GraphConnectorIT {
+
+    private static final String SCOPE = "https://graph.microsoft.com/.default";
+    private static final String TOKEN_URL_TEMPLATE = "https://login.microsoftonline.com/%s/oauth2/v2.0/token";
+
+    /**
+     * Default location of the IT properties file: {@code aad-sync-it.properties} in the project
+     * root. Maven always runs tests from the directory containing {@code pom.xml}, so a relative
+     * path is enough. The file is gitignored — see {@code .gitignore} and the committed
+     * {@code aad-sync-it.properties.example} template.
+     */
+    private static final String DEFAULT_CONFIG_PATH = "aad-sync-it.properties";
+
+    private static final Properties FILE_PROPS = loadFileProps();
+
+    private GraphConnector connector;
+    private String token;
+    private String groupPrefix;
+    private String extensionAppId;
+    private String extensionFields;
+    private FakeOAuth2SecurityConfiguration config;
+
+    @BeforeEach
+    void setUp() {
+        String tenantId = required("AAD_SYNC_IT_TENANT_ID", "tenantId");
+        String clientId = required("AAD_SYNC_IT_CLIENT_ID", "clientId");
+        String clientSecret = required("AAD_SYNC_IT_CLIENT_SECRET", "clientSecret");
+        groupPrefix = required("AAD_SYNC_IT_GROUP_PREFIX", "groupPrefix");
+
+        extensionAppId = lookup("AAD_SYNC_IT_EXTENSION_APP_ID", "extensionAppId", null);
+        extensionFields = lookup("AAD_SYNC_IT_EXTENSION_FIELDS", "extensionFields", null);
+        String mappingId = lookup("AAD_SYNC_IT_MAPPING_ID", "mappingId", "mailNickname");
+        String mappingName = lookup("AAD_SYNC_IT_MAPPING_NAME", "mappingName", "displayName");
+        String mappingEmail = lookup("AAD_SYNC_IT_MAPPING_EMAIL", "mappingEmail", "mail");
+
+        log("--- IT setup ---");
+        log("  tenantId        = " + tenantId);
+        log("  clientId        = " + clientId);
+        log("  clientSecret    = " + maskSecret(clientSecret));
+        log("  groupPrefix     = " + groupPrefix);
+        log("  extensionAppId  = " + (extensionAppId == null ? "(empty)" : extensionAppId));
+        log("  extensionFields = " + (extensionFields == null ? "(empty)" : extensionFields));
+        log("  mapping.id      = " + mappingId);
+        log("  mapping.name    = " + mappingName);
+        log("  mapping.email   = " + mappingEmail);
+        log("  config file     = " + resolvedConfigPath() + (FILE_PROPS.isEmpty() ? " (not loaded)" : " (loaded)"));
+
+        config = new FakeOAuth2SecurityConfiguration(mappingId, mappingName, mappingEmail);
+
+        // Use the real OAuth2Client code path that the production job uses, just constructed via
+        // the @VisibleForTesting constructor so we can skip the Polarion UserAccountVault.
+        OAuth2Client oauth2Client = new OAuth2Client(new OAuthClient(new URLConnectionClient()), null);
+        token = oauth2Client.getToken(String.format(TOKEN_URL_TEMPLATE, tenantId), clientId, clientSecret, SCOPE);
+        log("  token acquired  = " + maskSecret(token) + " (length=" + token.length() + ")");
+
+        connector = new GraphConnector(config, token, extensionAppId, extensionFields);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (connector != null) {
+            connector.close();
+        }
+    }
+
+    @Test
+    void clientCredentialsFlowReturnsToken() {
+        // setUp() already exercised the token acquisition; assert here so failures point at the
+        // right step instead of being hidden behind a downstream Graph call.
+        assertThat(token).isNotBlank();
+    }
+
+    @Test
+    void getGroupsReturnsAtLeastOneMatchingGroup() {
+        List<Group> groups = connector.getGroups(groupPrefix);
+
+        log("--- getGroups('" + groupPrefix + "') returned " + groups.size() + " group(s) ---");
+        for (Group group : groups) {
+            log("  group id = " + group.getId());
+        }
+
+        assertThat(groups)
+                .as("at least one AAD group with prefix '%s' must exist for the IT to be meaningful", groupPrefix)
+                .isNotEmpty();
+        assertThat(groups).allSatisfy(group -> assertThat(group.getId()).isNotBlank());
+    }
+
+    @Test
+    void getMembersResolvesAllMappedFieldsEndToEnd() {
+        List<Group> groups = connector.getGroups(groupPrefix);
+        log("--- getGroups('" + groupPrefix + "') returned " + groups.size() + " group(s) ---");
+        for (Group group : groups) {
+            log("  group id = " + group.getId());
+        }
+        assertThat(groups).isNotEmpty();
+        Group firstGroup = groups.get(0);
+
+        List<Member> members = connector.getMembers(firstGroup.getId());
+
+        log("--- getMembers('" + firstGroup.getId() + "') returned " + members.size() + " member(s) ---");
+        for (int i = 0; i < members.size(); i++) {
+            Member member = members.get(i);
+            log("  [" + i + "] id=" + valueOrNullMarker(member.getId())
+                    + " name=" + valueOrNullMarker(member.getName())
+                    + " email=" + valueOrNullMarker(member.getEmail()));
+        }
+
+        assertThat(members)
+                .as("group '%s' should have at least one member resolvable through the configured mapping", firstGroup.getId())
+                .isNotEmpty();
+
+        // Each member must have all three mapped fields resolved to non-null values. If any of
+        // these come back null we are reproducing issue #74 — Graph silently returns empty user
+        // objects when the $select asks for properties it does not understand.
+        assertThat(members).allSatisfy(member -> {
+            assertThat(member.getId()).as("member id must be resolved").isNotBlank();
+            assertThat(member.getName()).as("member name must be resolved").isNotBlank();
+            assertThat(member.getEmail()).as("member email must be resolved").isNotBlank();
+        });
+
+        String expectedUpn = lookup("AAD_SYNC_IT_EXPECTED_UPN", "expectedUpn", null);
+        if (expectedUpn != null && !expectedUpn.isBlank()) {
+            log("  asserting expectedUpn '" + expectedUpn + "' is among members");
+            assertThat(members)
+                    .as("expected user '%s' must be among resolved members", expectedUpn)
+                    .anySatisfy(member -> assertThat(member.getEmail()).isEqualToIgnoringCase(expectedUpn));
+        }
+    }
+
+    @Test
+    void getOrganizationDataReturnsTenantInfo() {
+        // Sanity check that Organization.Read.All is admin-consented and the /organization
+        // endpoint is reachable. The job uses this only when checkLastSynchronization=true.
+        var data = connector.getOrganizationData();
+        log("--- getOrganizationData() ---");
+        log("  onPremisesLastSyncDateTime = " + (data == null ? "(null)" : data.getOnPremisesLastSyncDateTime()));
+        assertThat(data).isNotNull();
+    }
+
+    /**
+     * Exercises the production wrapper {@link GraphService#getAadMemberIds(String)} end-to-end.
+     * The job's {@code runInternal} goes through this method, not directly through
+     * {@link GraphConnector#getMembers(String)}, so a regression in {@code GraphService}'s dedup
+     * or {@code id != null} filter would not be caught by the connector-level tests above.
+     * Asserts that the resolved set contains the same non-null ids that {@link GraphConnector}
+     * returns directly.
+     */
+    @Test
+    void graphServicePipelineDedupesAndFilters() {
+        GraphService service = new GraphService(connector);
+
+        Set<String> ids = service.getAadMemberIds(groupPrefix);
+
+        log("--- GraphService.getAadMemberIds('" + groupPrefix + "') ---");
+        log("  resolved " + ids.size() + " unique non-null id(s)");
+        ids.forEach(id -> log("  " + id));
+
+        assertThat(ids)
+                .as("GraphService should return at least one resolved member id for prefix '%s'", groupPrefix)
+                .isNotEmpty();
+        assertThat(ids).doesNotContainNull();
+        assertThat(ids).allSatisfy(id -> assertThat(id).isNotBlank());
+    }
+
+    /**
+     * The connector implements {@link AutoCloseable}; closing it twice must not throw. We rely
+     * on this in {@code UserSynchronizationJobUnit#runInternal}'s {@code finally} block, where a
+     * second close from a hypothetical future cleanup path would otherwise crash the job.
+     */
+    @Test
+    void connectorCloseIsIdempotent() {
+        GraphConnector throwaway = new GraphConnector(config, token, extensionAppId, extensionFields);
+        throwaway.close();
+        throwaway.close();   // must not throw
+    }
+
+    private static void log(String line) {
+        // Plain stdout — surefire forwards it to the console alongside the test result, no extra
+        // logger configuration needed. Use the IT logs to inspect what Graph actually returned
+        // when an assertion fails.
+        System.out.println("[GraphConnectorIT] " + line);
+    }
+
+    private static String valueOrNullMarker(String value) {
+        if (value == null) {
+            return "<NULL>";
+        }
+        if (value.isEmpty()) {
+            return "<EMPTY>";
+        }
+        return value;
+    }
+
+    /**
+     * Mask everything except the first 4 and last 4 characters of a secret-like value, so that
+     * the IT log shows enough to recognise the value but not enough to leak it. Short strings
+     * (under 12 chars) are fully masked.
+     */
+    private static String maskSecret(String value) {
+        if (value == null || value.isBlank()) {
+            return "(empty)";
+        }
+        if (value.length() < 12) {
+            return "***";
+        }
+        return value.substring(0, 4) + "..." + value.substring(value.length() - 4);
+    }
+
+    /**
+     * Resolves a configuration value by checking, in order: environment variable, JVM system
+     * property (under the same UPPER_SNAKE_CASE name), the loaded properties file (under the
+     * camelCase {@code fileKey}), and finally the supplied {@code defaultValue}. The first
+     * non-blank value wins. Returns {@code defaultValue} (which may be {@code null}) if nothing
+     * is configured.
+     */
+    private static String lookup(String envName, String fileKey, String defaultValue) {
+        String env = System.getenv(envName);
+        if (env != null && !env.isBlank()) {
+            return env;
+        }
+        String sysProp = System.getProperty(envName);
+        if (sysProp != null && !sysProp.isBlank()) {
+            return sysProp;
+        }
+        String fromFile = FILE_PROPS.getProperty(fileKey);
+        if (fromFile != null && !fromFile.isBlank()) {
+            return fromFile;
+        }
+        return defaultValue;
+    }
+
+    private static String required(String envName, String fileKey) {
+        String value = lookup(envName, fileKey, null);
+        if (value == null) {
+            throw new IllegalStateException(
+                    "Required IT setting is not configured. Set env var '" + envName
+                            + "' or system property '" + envName
+                            + "' or key '" + fileKey + "' in " + resolvedConfigPath());
+        }
+        return value;
+    }
+
+    /**
+     * Loads the optional properties file used as a fallback source of IT configuration. The path
+     * is taken from {@code AAD_SYNC_IT_CONFIG_FILE} (env or system property), or defaults to
+     * {@value #DEFAULT_CONFIG_PATH}-equivalent. A missing file is not an error — the IT will
+     * still pick up env/system properties if they're set.
+     */
+    private static Properties loadFileProps() {
+        Properties props = new Properties();
+        Path path = Path.of(resolvedConfigPath());
+        if (!Files.isReadable(path)) {
+            return props;
+        }
+        try (InputStream in = Files.newInputStream(path)) {
+            props.load(in);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read IT config file: " + path, e);
+        }
+        return props;
+    }
+
+    private static String resolvedConfigPath() {
+        String envPath = System.getenv("AAD_SYNC_IT_CONFIG_FILE");
+        if (envPath != null && !envPath.isBlank()) {
+            return envPath;
+        }
+        String sysPath = System.getProperty("aad-sync-it.config-file");
+        if (sysPath != null && !sysPath.isBlank()) {
+            return sysPath;
+        }
+        return DEFAULT_CONFIG_PATH;
+    }
+
+    /**
+     * Used by {@link EnabledIf @EnabledIf} on the class to skip the whole IT suite when the
+     * minimum required configuration is missing. Mirrors the four {@code required(...)} calls in
+     * {@link #setUp()} so we never reach an {@link IllegalStateException} during test execution
+     * in a misconfigured environment — the tests just don't run.
+     */
+    static boolean isConfigured() {
+        return lookup("AAD_SYNC_IT_TENANT_ID", "tenantId", null) != null
+                && lookup("AAD_SYNC_IT_CLIENT_ID", "clientId", null) != null
+                && lookup("AAD_SYNC_IT_CLIENT_SECRET", "clientSecret", null) != null
+                && lookup("AAD_SYNC_IT_GROUP_PREFIX", "groupPrefix", null) != null;
+    }
+}

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
@@ -14,12 +14,12 @@ import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.polarion.core.config.IOAuth2SecurityConfiguration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.Named;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.ws.rs.core.HttpHeaders;

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.polarion.core.config.IOAuth2SecurityConfiguration;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,13 +25,18 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -40,15 +46,39 @@ class GraphConnectorTest {
 
     private final IOAuth2SecurityConfiguration authenticationProviderConfiguration = new FakeOAuth2SecurityConfiguration();
     private final String groupPrefix = "test";
+    /**
+     * Tracks every {@link GraphConnector} created during a test so {@link #closeConnectors()} can
+     * release the underlying JAX-RS HTTP client. Each connector now allocates a real
+     * {@code Client} in its constructor (see {@code GraphConnector#httpClient}); leaving them open
+     * across tests would leak Jersey connection pools and trigger noisy finalizer warnings.
+     */
+    private final List<GraphConnector> connectorsToClose = new ArrayList<>();
+
+    @AfterEach
+    void closeConnectors() {
+        for (GraphConnector connector : connectorsToClose) {
+            try {
+                connector.close();
+            } catch (RuntimeException ignored) {
+                // best-effort cleanup; the test result is what matters
+            }
+        }
+        connectorsToClose.clear();
+    }
+
+    private GraphConnector register(GraphConnector connector) {
+        connectorsToClose.add(connector);
+        return connector;
+    }
 
     private GraphConnector createConnector(WireMockRuntimeInfo wmRuntimeInfo) {
-        return new GraphConnector(authenticationProviderConfiguration, "test", wmRuntimeInfo.getHttpBaseUrl());
+        return register(new GraphConnector(authenticationProviderConfiguration, "test", null, null, wmRuntimeInfo.getHttpBaseUrl()));
     }
 
     private static Stream<Arguments> testMemberValues() {
         return Stream.of(
-                Arguments.of("members.json", 5),
-                Arguments.of("emptyMembersList.json", 0)
+                Arguments.of("groupMemberIds.json", 5),
+                Arguments.of("emptyGroupMemberIds.json", 0)
         );
     }
 
@@ -73,6 +103,7 @@ class GraphConnectorTest {
     void getMembers(String pathToJson, Integer expectedSize, WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
         String memberId = "memberId";
         mockGetMemberCall(memberId, pathToJson, 200);
+        stubAnyUserCallWithMailNickname();
 
         List<Member> memberList = createConnector(wmRuntimeInfo).getMembers(memberId);
 
@@ -83,8 +114,9 @@ class GraphConnectorTest {
     void getPaginatedMembers(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
         String memberId = "memberId";
         String baseUrl = wmRuntimeInfo.getHttpBaseUrl();
-        mockGetMemberCallWithBody(memberId, getContent("membersPaginated.json").replace("http://localhost:1080", baseUrl), 200);
-        mockGetMemberCall("next", "members.json", 200);
+        mockGetMemberCallWithBody(memberId, getContent("groupMemberIdsPaginated.json").replace("http://localhost:1080", baseUrl), 200);
+        mockGetMemberCall("next", "groupMemberIds.json", 200);
+        stubAnyUserCallWithMailNickname();
 
         List<Member> memberList = createConnector(wmRuntimeInfo).getMembers(memberId);
 
@@ -94,12 +126,177 @@ class GraphConnectorTest {
     @Test
     void getMembersWithWrongStatusCode(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
         String memberId = "memberId";
-        mockGetMemberCall(memberId, "emptyMembersList.json", 222);
+        mockGetMemberCall(memberId, "emptyGroupMemberIds.json", 222);
 
         GraphConnector connector = createConnector(wmRuntimeInfo);
         assertThatThrownBy(() -> connector.getMembers(memberId))
                 .isInstanceOf(InvalidGraphResponseException.class)
                 .hasMessageContaining("Could not get proper response from Microsoft Graph");
+    }
+
+    @Test
+    void getMembersResolvesCustomExtensionAttribute(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
+        String groupKey = "myGroup";
+        String aadObjectId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+        String customAttribute = "extension_abc123def456_mycustomid";
+        String customValue = "1234";
+
+        FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration(customAttribute, "displayName", "mail");
+
+        // Group endpoint returns just the AAD object ids of the members
+        String groupBody = "{\"value\":[{\"@odata.type\":\"#microsoft.graph.user\",\"id\":\"" + aadObjectId + "\"}]}";
+        mockGetMemberCallWithBody(groupKey, groupBody, 200);
+
+        // /users/{id} returns the actual user object including the custom extension attribute
+        String userBody = "{\"@odata.type\":\"#microsoft.graph.user\","
+                + "\"" + customAttribute + "\":\"" + customValue + "\","
+                + "\"displayName\":\"Some User\","
+                + "\"mail\":\"some.user@example.com\"}";
+        mockGetUserCallWithBody(aadObjectId, userBody, 200);
+
+        GraphConnector connector = register(new GraphConnector(config, "test", null, null, wmRuntimeInfo.getHttpBaseUrl()));
+        List<Member> members = connector.getMembers(groupKey);
+
+        assertThat(members).hasSize(1);
+        assertThat(members.get(0).getId()).isEqualTo(customValue);
+        assertThat(members.get(0).getName()).isEqualTo("Some User");
+        assertThat(members.get(0).getEmail()).isEqualTo("some.user@example.com");
+    }
+
+    @Test
+    void getMembersResolvesNestedAttributePath(WireMockRuntimeInfo wmRuntimeInfo) {
+        String groupKey = "myGroup";
+        String aadObjectId = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+        String nestedPath = "onPremisesExtensionAttributes/extensionAttribute1";
+        String expectedValue = "EMP-42";
+
+        FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration(nestedPath, "displayName", "mail");
+
+        String groupBody = "{\"value\":[{\"@odata.type\":\"#microsoft.graph.user\",\"id\":\"" + aadObjectId + "\"}]}";
+        mockGetMemberCallWithBody(groupKey, groupBody, 200);
+
+        String userBody = "{\"@odata.type\":\"#microsoft.graph.user\","
+                + "\"onPremisesExtensionAttributes\":{\"extensionAttribute1\":\"" + expectedValue + "\"},"
+                + "\"displayName\":\"Nested User\","
+                + "\"mail\":\"nested.user@example.com\"}";
+        mockGetUserCallWithBody(aadObjectId, userBody, 200);
+
+        GraphConnector connector = register(new GraphConnector(config, "test", null, null, wmRuntimeInfo.getHttpBaseUrl()));
+        List<Member> members = connector.getMembers(groupKey);
+
+        assertThat(members).hasSize(1);
+        assertThat(members.get(0).getId()).isEqualTo(expectedValue);
+    }
+
+    @Test
+    void getMembersExpandsBareAttributeUsingExtensionAppId(WireMockRuntimeInfo wmRuntimeInfo) {
+        String groupKey = "myGroup";
+        String aadObjectId = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+        // The user puts only the bare claim name in authentication.xml...
+        String bareAttribute = "mycustomid";
+        // ...and the AAD application id (with dashes) in the extensionAppId job parameter.
+        String appId = "abc123de-f456-7890-abcd-ef1234567890";
+        String appIdNoDashes = "abc123def4567890abcdef1234567890";
+        String expandedAttribute = "extension_" + appIdNoDashes + "_" + bareAttribute;
+        String customValue = "9876";
+
+        FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration(bareAttribute, "displayName", "mail");
+
+        String groupBody = "{\"value\":[{\"@odata.type\":\"#microsoft.graph.user\",\"id\":\"" + aadObjectId + "\"}]}";
+        mockGetMemberCallWithBody(groupKey, groupBody, 200);
+
+        // The /users/{id} response uses the fully-qualified Graph property name
+        String userBody = "{\"@odata.type\":\"#microsoft.graph.user\","
+                + "\"" + expandedAttribute + "\":\"" + customValue + "\","
+                + "\"displayName\":\"Bare User\","
+                + "\"mail\":\"bare.user@example.com\"}";
+        mockGetUserCallWithBody(aadObjectId, userBody, 200);
+
+        // extensionFields not set → defaults to "id" so the bare attribute gets expanded
+        GraphConnector connector = register(new GraphConnector(config, "test", appId, null, wmRuntimeInfo.getHttpBaseUrl()));
+        List<Member> members = connector.getMembers(groupKey);
+
+        assertThat(members).hasSize(1);
+        assertThat(members.get(0).getId()).isEqualTo(customValue);
+        // The Graph $select query should also have used the expanded attribute name
+        com.github.tomakehurst.wiremock.client.WireMock.verify(
+                com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor(urlPathEqualTo("/v1.0/users/" + aadObjectId))
+                        .withQueryParam("$select", com.github.tomakehurst.wiremock.client.WireMock.containing(expandedAttribute)));
+    }
+
+    @Test
+    void getMembersExpandsMultipleFieldsViaExtensionFields(WireMockRuntimeInfo wmRuntimeInfo) {
+        String groupKey = "myGroup";
+        String aadObjectId = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+        String appId = "abc-123";
+        String appIdNoDashes = "abc123";
+        // id and email are custom extensions; name stays standard
+        String bareId = "mycustomid";
+        String bareEmail = "myworkmail";
+        String expandedId = "extension_" + appIdNoDashes + "_" + bareId;
+        String expandedEmail = "extension_" + appIdNoDashes + "_" + bareEmail;
+
+        FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration(bareId, "displayName", bareEmail);
+
+        String groupBody = "{\"value\":[{\"@odata.type\":\"#microsoft.graph.user\",\"id\":\"" + aadObjectId + "\"}]}";
+        mockGetMemberCallWithBody(groupKey, groupBody, 200);
+
+        String userBody = "{\"@odata.type\":\"#microsoft.graph.user\","
+                + "\"" + expandedId + "\":\"the-id\","
+                + "\"displayName\":\"Multi User\","
+                + "\"" + expandedEmail + "\":\"work@example.com\"}";
+        mockGetUserCallWithBody(aadObjectId, userBody, 200);
+
+        GraphConnector connector = register(new GraphConnector(config, "test", appId, "id, email", wmRuntimeInfo.getHttpBaseUrl()));
+        List<Member> members = connector.getMembers(groupKey);
+
+        assertThat(members).hasSize(1);
+        assertThat(members.get(0).getId()).isEqualTo("the-id");
+        assertThat(members.get(0).getName()).isEqualTo("Multi User");
+        assertThat(members.get(0).getEmail()).isEqualTo("work@example.com");
+        // Both expanded names must be present in the $select query, displayName must remain standard
+        com.github.tomakehurst.wiremock.client.WireMock.verify(
+                com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor(urlPathEqualTo("/v1.0/users/" + aadObjectId))
+                        .withQueryParam("$select", com.github.tomakehurst.wiremock.client.WireMock.containing(expandedId))
+                        .withQueryParam("$select", com.github.tomakehurst.wiremock.client.WireMock.containing("displayName"))
+                        .withQueryParam("$select", com.github.tomakehurst.wiremock.client.WireMock.containing(expandedEmail)));
+    }
+
+    @Test
+    void expandExtensionAttributeBehaviour() {
+        FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration();
+        // No extensionAppId → bare name passes through unchanged
+        GraphConnector noAppIdConnector = register(new GraphConnector(config, "test", null, null, "http://localhost"));
+        assertThat(noAppIdConnector.expandExtensionAttribute("mycustomid")).isEqualTo("mycustomid");
+
+        // With extensionAppId → bare name gets expanded, dashes stripped from appId
+        GraphConnector withAppIdConnector = register(new GraphConnector(config, "test", "abc-123-def", null, "http://localhost"));
+        assertThat(withAppIdConnector.expandExtensionAttribute("mycustomid")).isEqualTo("extension_abc123def_mycustomid");
+        // Already-qualified name is not double-prefixed
+        assertThat(withAppIdConnector.expandExtensionAttribute("extension_xxx_yyy")).isEqualTo("extension_xxx_yyy");
+        // Nested path is left untouched
+        assertThat(withAppIdConnector.expandExtensionAttribute("onPremisesExtensionAttributes/extensionAttribute1"))
+                .isEqualTo("onPremisesExtensionAttributes/extensionAttribute1");
+    }
+
+    @Test
+    void expandIfMarkedRespectsExtensionFields() {
+        FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration();
+
+        // Default: extensionFields unset and extensionAppId set → defaults to {id}
+        GraphConnector defaultConnector = register(new GraphConnector(config, "test", "abc-123", null, "http://localhost"));
+        assertThat(defaultConnector.expandIfMarked("id", "mycustomid")).isEqualTo("extension_abc123_mycustomid");
+        assertThat(defaultConnector.expandIfMarked("email", "mail")).isEqualTo("mail");
+
+        // Explicit list of fields
+        GraphConnector multiConnector = register(new GraphConnector(config, "test", "abc-123", "id,email", "http://localhost"));
+        assertThat(multiConnector.expandIfMarked("id", "mycustomid")).isEqualTo("extension_abc123_mycustomid");
+        assertThat(multiConnector.expandIfMarked("name", "displayName")).isEqualTo("displayName");
+        assertThat(multiConnector.expandIfMarked("email", "myworkmail")).isEqualTo("extension_abc123_myworkmail");
+
+        // No appId, no fields → nothing happens
+        GraphConnector noopConnector = register(new GraphConnector(config, "test", null, null, "http://localhost"));
+        assertThat(noopConnector.expandIfMarked("id", "mycustomid")).isEqualTo("mycustomid");
     }
 
     @Test
@@ -147,6 +344,216 @@ class GraphConnectorTest {
     }
 
     @Test
+    void retriesOnTooManyRequestsAndSucceeds(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
+        String scenario = "throttled-groups";
+        stubFor(get(urlPathEqualTo("/v1.0/groups"))
+                .inScenario(scenario)
+                .whenScenarioStateIs(STARTED)
+                .willReturn(aResponse().withStatus(429).withHeader("Retry-After", "0"))
+                .willSetStateTo("retried"));
+        stubFor(get(urlPathEqualTo("/v1.0/groups"))
+                .inScenario(scenario)
+                .whenScenarioStateIs("retried")
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json; charset=utf-8")
+                        .withBody(getContent("groups.json"))));
+
+        List<Group> groups = createConnector(wmRuntimeInfo).getGroups(groupPrefix);
+
+        assertThat(groups).hasSize(5);
+        verify(2, getRequestedFor(urlPathEqualTo("/v1.0/groups")));
+    }
+
+    @Test
+    void retriesOnServiceUnavailableWithoutRetryAfterHeader(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
+        String scenario = "unavailable-groups";
+        stubFor(get(urlPathEqualTo("/v1.0/groups"))
+                .inScenario(scenario)
+                .whenScenarioStateIs(STARTED)
+                .willReturn(aResponse().withStatus(503))
+                .willSetStateTo("recovered"));
+        stubFor(get(urlPathEqualTo("/v1.0/groups"))
+                .inScenario(scenario)
+                .whenScenarioStateIs("recovered")
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json; charset=utf-8")
+                        .withBody(getContent("groups.json"))));
+
+        // Without Retry-After the connector falls back to its 1s exponential backoff base — that's
+        // an acceptable test cost (single sleep) versus introducing a clock seam just for tests.
+        List<Group> groups = createConnector(wmRuntimeInfo).getGroups(groupPrefix);
+
+        assertThat(groups).hasSize(5);
+        verify(2, getRequestedFor(urlPathEqualTo("/v1.0/groups")));
+    }
+
+    @Test
+    void givesUpAfterMaxRetriesOnPersistentThrottling(WireMockRuntimeInfo wmRuntimeInfo) {
+        stubFor(get(urlPathEqualTo("/v1.0/groups"))
+                .willReturn(aResponse().withStatus(429).withHeader("Retry-After", "0")));
+
+        GraphConnector connector = createConnector(wmRuntimeInfo);
+        assertThatThrownBy(() -> connector.getGroups(groupPrefix))
+                .isInstanceOf(InvalidGraphResponseException.class)
+                .hasMessageContaining("Could not get proper response from Microsoft Graph");
+
+        // MAX_RETRIES = 5, so the total number of attempts is 6.
+        verify(6, getRequestedFor(urlPathEqualTo("/v1.0/groups")));
+    }
+
+    @Test
+    void getMembersFiltersOutNonUserDirectoryObjects(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
+        // /groups/{id}/members can return any directory object: users, nested groups, service
+        // principals, devices. Only #microsoft.graph.user ids must propagate to /users/{id} —
+        // everything else would 404 there and crash the entire job. Fixture has 6 members of
+        // mixed types; only the 3 user-typed ones should be followed up.
+        String groupKey = "groupWithMixedMembers";
+        mockGetMemberCall(groupKey, "groupMembersMixedTypes.json", 200);
+        stubAnyUserCallWithMailNickname();
+
+        List<Member> members = createConnector(wmRuntimeInfo).getMembers(groupKey);
+
+        assertThat(members).hasSize(3);
+
+        // Positive proof: WireMock saw /users/{id} requests for the user ids only.
+        verify(1, getRequestedFor(urlPathEqualTo("/v1.0/users/11111111-1111-1111-1111-111111111111")));
+        verify(1, getRequestedFor(urlPathEqualTo("/v1.0/users/33333333-3333-3333-3333-333333333333")));
+        verify(1, getRequestedFor(urlPathEqualTo("/v1.0/users/66666666-6666-6666-6666-666666666666")));
+        // Negative proof: nested group / service principal / device ids must not be requested.
+        verify(0, getRequestedFor(urlPathEqualTo("/v1.0/users/22222222-2222-2222-2222-222222222222")));
+        verify(0, getRequestedFor(urlPathEqualTo("/v1.0/users/44444444-4444-4444-4444-444444444444")));
+        verify(0, getRequestedFor(urlPathEqualTo("/v1.0/users/55555555-5555-5555-5555-555555555555")));
+    }
+
+    @Test
+    void getMembersParsesRealisticUserResponseWithExtensionAttributes(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
+        // The fixture mirrors the actual /users/{id}/$entity shape returned by Microsoft Graph
+        // when extension property names are used in $select: a flat object with @odata.context,
+        // standard fields (id, displayName, userPrincipalName) and extension_<appIdNoDashes>_<name>
+        // properties at the top level. No 'value' wrapper.
+        String groupKey = "myGroup";
+        String aadObjectId = "11111111-1111-1111-1111-111111111111";
+        // The bare names that appear in authentication.xml — same as the customer scenario.
+        String mappingId = "mycustomid";
+        String mappingName = "name";
+        String mappingEmail = "email";
+        // The extension owner app id (with dashes) configured as extensionAppId job parameter.
+        // Stripping dashes yields aaaaaaaabbbbccccddddeeeeeeeeeeee, which the fixture uses.
+        String extensionAppId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+        FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration(mappingId, mappingName, mappingEmail);
+
+        // Group endpoint returns just the AAD object id.
+        String groupBody = "{\"value\":[{\"@odata.type\":\"#microsoft.graph.user\",\"id\":\"" + aadObjectId + "\"}]}";
+        mockGetMemberCallWithBody(groupKey, groupBody, 200);
+        // /users/{id} returns the realistic Graph response loaded from the fixture.
+        mockGetUserCallWithBody(aadObjectId, getContent("userWithExtensionAttributes.json"), 200);
+
+        GraphConnector connector = register(new GraphConnector(config, "test", extensionAppId, "id,name,email", wmRuntimeInfo.getHttpBaseUrl()));
+        List<Member> members = connector.getMembers(groupKey);
+
+        assertThat(members).hasSize(1);
+        Member member = members.get(0);
+        assertThat(member.getId()).isEqualTo("anonymous-id-001");
+        assertThat(member.getName()).isEqualTo("John Doe");
+        assertThat(member.getEmail()).isEqualTo("john.doe@example.com");
+
+        // The Graph $select must reference the fully-expanded extension property names — that's
+        // exactly what makes the difference between issue #74 and a working request.
+        String expandedId = "extension_aaaaaaaabbbbccccddddeeeeeeeeeeee_mycustomid";
+        String expandedName = "extension_aaaaaaaabbbbccccddddeeeeeeeeeeee_name";
+        String expandedEmail = "extension_aaaaaaaabbbbccccddddeeeeeeeeeeee_email";
+        verify(getRequestedFor(urlPathEqualTo("/v1.0/users/" + aadObjectId))
+                .withQueryParam("$select", com.github.tomakehurst.wiremock.client.WireMock.containing(expandedId))
+                .withQueryParam("$select", com.github.tomakehurst.wiremock.client.WireMock.containing(expandedName))
+                .withQueryParam("$select", com.github.tomakehurst.wiremock.client.WireMock.containing(expandedEmail)));
+    }
+
+    @Test
+    void getMembersParsesRealisticUserResponseWithVanillaAttributes(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
+        // Vanilla MS Graph properties: mailNickname/displayName/mail. No extensionAppId, no
+        // extensionFields — bare names go straight into $select. Validates the simplest possible
+        // synchronizer configuration end-to-end through the parser.
+        String groupKey = "myGroup";
+        String aadObjectId = "11111111-1111-1111-1111-111111111111";
+
+        // Default FakeOAuth2SecurityConfiguration() uses mailNickname/displayName/mail.
+        FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration();
+
+        String groupBody = "{\"value\":[{\"@odata.type\":\"#microsoft.graph.user\",\"id\":\"" + aadObjectId + "\"}]}";
+        mockGetMemberCallWithBody(groupKey, groupBody, 200);
+        mockGetUserCallWithBody(aadObjectId, getContent("userWithVanillaAttributes.json"), 200);
+
+        GraphConnector connector = register(new GraphConnector(config, "test", null, null, wmRuntimeInfo.getHttpBaseUrl()));
+        List<Member> members = connector.getMembers(groupKey);
+
+        assertThat(members).hasSize(1);
+        Member member = members.get(0);
+        assertThat(member.getId()).isEqualTo("john.doe");
+        assertThat(member.getName()).isEqualTo("John Doe");
+        assertThat(member.getEmail()).isEqualTo("john.doe@example.com");
+    }
+
+    @Test
+    void getMembersHandlesUserWithMissingExtensionValue(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
+        // The customer's extension property exists on the schema but the user has not been
+        // assigned a value for it (Graph returns the field with literal JSON null). The parser
+        // must produce a Member with id == null without crashing — GraphService will then drop
+        // it from the synchronization set via its non-null filter. Other resolved fields must
+        // still come through normally.
+        String groupKey = "myGroup";
+        String aadObjectId = "11111111-1111-1111-1111-111111111111";
+        String extensionAppId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+        FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration("mycustomid", "name", "email");
+
+        String groupBody = "{\"value\":[{\"@odata.type\":\"#microsoft.graph.user\",\"id\":\"" + aadObjectId + "\"}]}";
+        mockGetMemberCallWithBody(groupKey, groupBody, 200);
+        mockGetUserCallWithBody(aadObjectId, getContent("userWithMissingExtensionValue.json"), 200);
+
+        GraphConnector connector = register(new GraphConnector(config, "test", extensionAppId, "id,name,email", wmRuntimeInfo.getHttpBaseUrl()));
+        List<Member> members = connector.getMembers(groupKey);
+
+        assertThat(members).hasSize(1);
+        Member member = members.get(0);
+        assertThat(member.getId()).isNull();
+        assertThat(member.getName()).isEqualTo("John Doe");
+        assertThat(member.getEmail()).isEqualTo("john.doe@example.com");
+    }
+
+    @Test
+    void getMembersHandlesMinimalUserEntityWhenSelectIsSilentlyDropped(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
+        // When $select references property names that Graph does not understand (the issue #74
+        // failure mode, but at the per-user endpoint), Graph returns a /users/{id}/$entity body
+        // containing only @odata.context — no id, no @odata.type, none of the requested fields.
+        // The parser must not crash. All Member fields end up null. GraphService.getAadMemberIds
+        // would silently drop this user via its non-null id filter, which is the silent failure
+        // mode this test pins down — anyone breaking the extension expansion logic will see this
+        // test fail with a clear pointer to the regression.
+        String groupKey = "myGroup";
+        String aadObjectId = "11111111-1111-1111-1111-111111111111";
+
+        // Customer-style mapping but WITHOUT extensionAppId — so expandIfMarked returns the bare
+        // names unchanged, and Graph silently drops them.
+        FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration("mycustomid", "name", "email");
+
+        String groupBody = "{\"value\":[{\"@odata.type\":\"#microsoft.graph.user\",\"id\":\"" + aadObjectId + "\"}]}";
+        mockGetMemberCallWithBody(groupKey, groupBody, 200);
+        mockGetUserCallWithBody(aadObjectId, getContent("userMinimalEntity.json"), 200);
+
+        GraphConnector connector = register(new GraphConnector(config, "test", null, null, wmRuntimeInfo.getHttpBaseUrl()));
+        List<Member> members = connector.getMembers(groupKey);
+
+        assertThat(members).hasSize(1);
+        Member member = members.get(0);
+        assertThat(member.getId()).isNull();
+        assertThat(member.getName()).isNull();
+        assertThat(member.getEmail()).isNull();
+    }
+
+    @Test
     void wrongJsonDataResponse(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
         String memberId = "memberId";
 
@@ -159,8 +566,12 @@ class GraphConnectorTest {
                 .isInstanceOf(ResponseParsingException.class);
         assertThatThrownBy(connector::getOrganizationData)
                 .isInstanceOf(ResponseParsingException.class);
+        // After the @odata.type filtering refactor, fetchGroupMemberObjectIds parses the response
+        // body itself and wraps any JsonProcessingException in ResponseParsingException — same as
+        // getGroups/getOrganizationData. Previously the leaf parser leaked JsonParseException
+        // through, which was inconsistent with the rest of the connector API.
         assertThatThrownBy(() -> connector.getMembers(memberId))
-                .isInstanceOf(JsonParseException.class);
+                .isInstanceOf(ResponseParsingException.class);
     }
 
     private void mockGetGroupsCall(String path, Integer statusCode) throws IOException {
@@ -189,6 +600,30 @@ class GraphConnectorTest {
                         .withStatus(statusCode)
                         .withHeader("Content-Type", "application/json; charset=utf-8")
                         .withBody(body)));
+    }
+
+    private void mockGetUserCallWithBody(String userId, String body, Integer statusCode) {
+        stubFor(get(urlPathEqualTo("/v1.0/users/" + userId))
+                .willReturn(aResponse()
+                        .withStatus(statusCode)
+                        .withHeader("Content-Type", "application/json; charset=utf-8")
+                        .withBody(body)));
+    }
+
+    /**
+     * Stubs every {@code /v1.0/users/{id}} request with a response containing the standard
+     * mailNickname/displayName/mail fields the default {@link FakeOAuth2SecurityConfiguration} expects.
+     * Used by tests that don't care about per-user details, only that the right number of members is returned.
+     */
+    private void stubAnyUserCallWithMailNickname() {
+        stubFor(get(urlPathMatching("/v1\\.0/users/.+"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json; charset=utf-8")
+                        .withBody("{\"@odata.type\":\"#microsoft.graph.user\","
+                                + "\"mailNickname\":\"someUser\","
+                                + "\"displayName\":\"Some User\","
+                                + "\"mail\":\"some.user@example.com\"}")));
     }
 
     private String getContent(String path) throws IOException {

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
@@ -395,58 +395,42 @@ class GraphConnectorTest {
         verify(2, getRequestedFor(urlPathEqualTo("/v1.0/groups")));
     }
 
-    @Test
-    void computeBackoffMillisHonoursRetryAfterHeaderWhenPresent() {
-        Response response = mock(Response.class);
-        when(response.getHeaderString(HttpHeaders.RETRY_AFTER)).thenReturn("5");
+    private static Stream<Arguments> retryAfterHeaderCases() {
+        // Header value → expected backoff at attempt=0. Covers both branches of
+        // computeBackoffMillis: integer-seconds parsing (with capping at MAX_BACKOFF_MILLIS)
+        // and the exponential-base fallback for missing / non-parseable / negative headers.
+        return Stream.of(
+                Arguments.of("integer seconds, well below cap",            "5",                                  5_000L),
+                Arguments.of("integer seconds, capped at MAX_BACKOFF",      "9999",                               60_000L),
+                Arguments.of("absent header → exponential base",            null,                                 1_000L),
+                Arguments.of("HTTP-date format → exponential base",         "Wed, 21 Oct 2026 07:28:00 GMT",      1_000L),
+                Arguments.of("negative value → exponential base",           "-1",                                 1_000L),
+                Arguments.of("blank string → exponential base",             "   ",                                1_000L)
+        );
+    }
 
-        // 5 seconds × 1000 ms — the Retry-After header always wins over exponential backoff
-        // and overrides whatever attempt counter the caller passed in.
-        assertThat(GraphConnector.computeBackoffMillis(response, 0)).isEqualTo(5_000L);
-        assertThat(GraphConnector.computeBackoffMillis(response, 4)).isEqualTo(5_000L);
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("retryAfterHeaderCases")
+    void computeBackoffMillisRespectsRetryAfterHeaderOrFallsBack(String description, String headerValue, long expectedMillis) {
+        Response response = mock(Response.class);
+        when(response.getHeaderString(HttpHeaders.RETRY_AFTER)).thenReturn(headerValue);
+
+        assertThat(GraphConnector.computeBackoffMillis(response, 0)).isEqualTo(expectedMillis);
     }
 
     @Test
-    void computeBackoffMillisCapsRetryAfterAtMaxBackoff() {
-        Response response = mock(Response.class);
-        when(response.getHeaderString(HttpHeaders.RETRY_AFTER)).thenReturn("9999");
-
-        // MAX_BACKOFF_MILLIS = 60_000 — protects against pathological Retry-After values that
-        // would otherwise stall the job for hours.
-        assertThat(GraphConnector.computeBackoffMillis(response, 0)).isEqualTo(60_000L);
-    }
-
-    @Test
-    void computeBackoffMillisFallsBackToExponentialBackoffWithoutRetryAfter() {
+    void computeBackoffMillisProducesExponentialSequenceCappedAtMax() {
+        // Different axis from the parameterized test above: header is fixed (absent), the
+        // attempt counter varies. Verifies the doubling sequence and the cap behaviour.
         Response response = mock(Response.class);
         when(response.getHeaderString(HttpHeaders.RETRY_AFTER)).thenReturn(null);
 
-        // Pure unit test for the no-Retry-After branch — replaces the slow wiremock variant that
-        // used to sleep one full second per run. Sequence: 1s, 2s, 4s, 8s, 16s, capped at 60s.
         assertThat(GraphConnector.computeBackoffMillis(response, 0)).isEqualTo(1_000L);
         assertThat(GraphConnector.computeBackoffMillis(response, 1)).isEqualTo(2_000L);
         assertThat(GraphConnector.computeBackoffMillis(response, 2)).isEqualTo(4_000L);
         assertThat(GraphConnector.computeBackoffMillis(response, 3)).isEqualTo(8_000L);
         assertThat(GraphConnector.computeBackoffMillis(response, 4)).isEqualTo(16_000L);
         assertThat(GraphConnector.computeBackoffMillis(response, 10)).isEqualTo(60_000L);
-    }
-
-    @Test
-    void computeBackoffMillisFallsBackWhenRetryAfterIsNotANumber() {
-        Response response = mock(Response.class);
-        // RFC 7231 also allows HTTP-date format — we don't parse it, the unit must still
-        // produce a positive backoff via exponential fallback so the retry actually happens.
-        when(response.getHeaderString(HttpHeaders.RETRY_AFTER)).thenReturn("Wed, 21 Oct 2026 07:28:00 GMT");
-
-        assertThat(GraphConnector.computeBackoffMillis(response, 0)).isEqualTo(1_000L);
-    }
-
-    @Test
-    void computeBackoffMillisFallsBackWhenRetryAfterIsNegative() {
-        Response response = mock(Response.class);
-        when(response.getHeaderString(HttpHeaders.RETRY_AFTER)).thenReturn("-1");
-
-        assertThat(GraphConnector.computeBackoffMillis(response, 0)).isEqualTo(1_000L);
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.Named;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.ws.rs.core.HttpHeaders;
@@ -399,19 +400,21 @@ class GraphConnectorTest {
         // Header value → expected backoff at attempt=0. Covers both branches of
         // computeBackoffMillis: integer-seconds parsing (with capping at MAX_BACKOFF_MILLIS)
         // and the exponential-base fallback for missing / non-parseable / negative headers.
+        // Each header value is wrapped in Named.named(...) so the display name lives next to
+        // the value rather than as a separate (unused) test parameter.
         return Stream.of(
-                Arguments.of("integer seconds, well below cap",            "5",                                  5_000L),
-                Arguments.of("integer seconds, capped at MAX_BACKOFF",      "9999",                               60_000L),
-                Arguments.of("absent header → exponential base",            null,                                 1_000L),
-                Arguments.of("HTTP-date format → exponential base",         "Wed, 21 Oct 2026 07:28:00 GMT",      1_000L),
-                Arguments.of("negative value → exponential base",           "-1",                                 1_000L),
-                Arguments.of("blank string → exponential base",             "   ",                                1_000L)
+                Arguments.of(Named.named("integer seconds, well below cap",        "5"),                                5_000L),
+                Arguments.of(Named.named("integer seconds, capped at MAX_BACKOFF", "9999"),                             60_000L),
+                Arguments.of(Named.named("absent header → exponential base",       null),                               1_000L),
+                Arguments.of(Named.named("HTTP-date format → exponential base",    "Wed, 21 Oct 2026 07:28:00 GMT"),    1_000L),
+                Arguments.of(Named.named("negative value → exponential base",      "-1"),                               1_000L),
+                Arguments.of(Named.named("blank string → exponential base",        "   "),                              1_000L)
         );
     }
 
     @ParameterizedTest(name = "[{index}] {0}")
     @MethodSource("retryAfterHeaderCases")
-    void computeBackoffMillisRespectsRetryAfterHeaderOrFallsBack(String description, String headerValue, long expectedMillis) {
+    void computeBackoffMillisRespectsRetryAfterHeaderOrFallsBack(String headerValue, long expectedMillis) {
         Response response = mock(Response.class);
         when(response.getHeaderString(HttpHeaders.RETRY_AFTER)).thenReturn(headerValue);
 

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -38,6 +40,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @WireMockTest
@@ -366,12 +370,16 @@ class GraphConnectorTest {
     }
 
     @Test
-    void retriesOnServiceUnavailableWithoutRetryAfterHeader(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
+    void retriesOnServiceUnavailableAndSucceeds(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
+        // Validates the end-to-end retry path on 503: first attempt fails, second succeeds.
+        // Uses Retry-After: 0 explicitly so the connector does not actually sleep — the
+        // exponential-backoff fallback (no Retry-After header) is exercised separately by the
+        // pure unit tests on computeBackoffMillis below to keep this suite fast.
         String scenario = "unavailable-groups";
         stubFor(get(urlPathEqualTo("/v1.0/groups"))
                 .inScenario(scenario)
                 .whenScenarioStateIs(STARTED)
-                .willReturn(aResponse().withStatus(503))
+                .willReturn(aResponse().withStatus(503).withHeader("Retry-After", "0"))
                 .willSetStateTo("recovered"));
         stubFor(get(urlPathEqualTo("/v1.0/groups"))
                 .inScenario(scenario)
@@ -381,12 +389,64 @@ class GraphConnectorTest {
                         .withHeader("Content-Type", "application/json; charset=utf-8")
                         .withBody(getContent("groups.json"))));
 
-        // Without Retry-After the connector falls back to its 1s exponential backoff base — that's
-        // an acceptable test cost (single sleep) versus introducing a clock seam just for tests.
         List<Group> groups = createConnector(wmRuntimeInfo).getGroups(groupPrefix);
 
         assertThat(groups).hasSize(5);
         verify(2, getRequestedFor(urlPathEqualTo("/v1.0/groups")));
+    }
+
+    @Test
+    void computeBackoffMillisHonoursRetryAfterHeaderWhenPresent() {
+        Response response = mock(Response.class);
+        when(response.getHeaderString(HttpHeaders.RETRY_AFTER)).thenReturn("5");
+
+        // 5 seconds × 1000 ms — the Retry-After header always wins over exponential backoff
+        // and overrides whatever attempt counter the caller passed in.
+        assertThat(GraphConnector.computeBackoffMillis(response, 0)).isEqualTo(5_000L);
+        assertThat(GraphConnector.computeBackoffMillis(response, 4)).isEqualTo(5_000L);
+    }
+
+    @Test
+    void computeBackoffMillisCapsRetryAfterAtMaxBackoff() {
+        Response response = mock(Response.class);
+        when(response.getHeaderString(HttpHeaders.RETRY_AFTER)).thenReturn("9999");
+
+        // MAX_BACKOFF_MILLIS = 60_000 — protects against pathological Retry-After values that
+        // would otherwise stall the job for hours.
+        assertThat(GraphConnector.computeBackoffMillis(response, 0)).isEqualTo(60_000L);
+    }
+
+    @Test
+    void computeBackoffMillisFallsBackToExponentialBackoffWithoutRetryAfter() {
+        Response response = mock(Response.class);
+        when(response.getHeaderString(HttpHeaders.RETRY_AFTER)).thenReturn(null);
+
+        // Pure unit test for the no-Retry-After branch — replaces the slow wiremock variant that
+        // used to sleep one full second per run. Sequence: 1s, 2s, 4s, 8s, 16s, capped at 60s.
+        assertThat(GraphConnector.computeBackoffMillis(response, 0)).isEqualTo(1_000L);
+        assertThat(GraphConnector.computeBackoffMillis(response, 1)).isEqualTo(2_000L);
+        assertThat(GraphConnector.computeBackoffMillis(response, 2)).isEqualTo(4_000L);
+        assertThat(GraphConnector.computeBackoffMillis(response, 3)).isEqualTo(8_000L);
+        assertThat(GraphConnector.computeBackoffMillis(response, 4)).isEqualTo(16_000L);
+        assertThat(GraphConnector.computeBackoffMillis(response, 10)).isEqualTo(60_000L);
+    }
+
+    @Test
+    void computeBackoffMillisFallsBackWhenRetryAfterIsNotANumber() {
+        Response response = mock(Response.class);
+        // RFC 7231 also allows HTTP-date format — we don't parse it, the unit must still
+        // produce a positive backoff via exponential fallback so the retry actually happens.
+        when(response.getHeaderString(HttpHeaders.RETRY_AFTER)).thenReturn("Wed, 21 Oct 2026 07:28:00 GMT");
+
+        assertThat(GraphConnector.computeBackoffMillis(response, 0)).isEqualTo(1_000L);
+    }
+
+    @Test
+    void computeBackoffMillisFallsBackWhenRetryAfterIsNegative() {
+        Response response = mock(Response.class);
+        when(response.getHeaderString(HttpHeaders.RETRY_AFTER)).thenReturn("-1");
+
+        assertThat(GraphConnector.computeBackoffMillis(response, 0)).isEqualTo(1_000L);
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
@@ -7,7 +7,6 @@ import ch.sbb.polarion.extension.aad.synchronizer.model.Group;
 import ch.sbb.polarion.extension.aad.synchronizer.model.Member;
 import ch.sbb.polarion.extension.aad.synchronizer.model.OrganizationData;
 import ch.sbb.polarion.extension.aad.synchronizer.model.OrganizationDataWrapper;
-import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
@@ -135,7 +134,7 @@ class GraphConnectorTest {
     }
 
     @Test
-    void getMembersResolvesCustomExtensionAttribute(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
+    void getMembersResolvesCustomExtensionAttribute(WireMockRuntimeInfo wmRuntimeInfo) {
         String groupKey = "myGroup";
         String aadObjectId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
         String customAttribute = "extension_abc123def456_mycustomid";
@@ -283,7 +282,8 @@ class GraphConnectorTest {
     void expandIfMarkedRespectsExtensionFields() {
         FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration();
 
-        // Default: extensionFields unset and extensionAppId set → defaults to {id}
+        // Default behaviour when no explicit extensionFields list is given but an extensionAppId is
+        // configured: only the id mapping role is auto-expanded.
         GraphConnector defaultConnector = register(new GraphConnector(config, "test", "abc-123", null, "http://localhost"));
         assertThat(defaultConnector.expandIfMarked("id", "mycustomid")).isEqualTo("extension_abc123_mycustomid");
         assertThat(defaultConnector.expandIfMarked("email", "mail")).isEqualTo("mail");

--- a/src/test/resources/emptyGroupMemberIds.json
+++ b/src/test/resources/emptyGroupMemberIds.json
@@ -1,0 +1,4 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#directoryObjects(id)",
+  "value": []
+}

--- a/src/test/resources/groupMemberIds.json
+++ b/src/test/resources/groupMemberIds.json
@@ -1,0 +1,25 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#directoryObjects(id)",
+  "value": [
+    {
+      "@odata.type": "#microsoft.graph.user",
+      "id": "00000000-0000-0000-0000-000000000001"
+    },
+    {
+      "@odata.type": "#microsoft.graph.user",
+      "id": "00000000-0000-0000-0000-000000000002"
+    },
+    {
+      "@odata.type": "#microsoft.graph.user",
+      "id": "00000000-0000-0000-0000-000000000003"
+    },
+    {
+      "@odata.type": "#microsoft.graph.user",
+      "id": "00000000-0000-0000-0000-000000000004"
+    },
+    {
+      "@odata.type": "#microsoft.graph.user",
+      "id": "00000000-0000-0000-0000-000000000005"
+    }
+  ]
+}

--- a/src/test/resources/groupMemberIdsPaginated.json
+++ b/src/test/resources/groupMemberIdsPaginated.json
@@ -1,0 +1,18 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#directoryObjects(id)",
+  "@odata.nextLink": "http://localhost:1080/v1.0/groups/next/members",
+  "value": [
+    {
+      "@odata.type": "#microsoft.graph.user",
+      "id": "00000000-0000-0000-0000-000000000010"
+    },
+    {
+      "@odata.type": "#microsoft.graph.user",
+      "id": "00000000-0000-0000-0000-000000000011"
+    },
+    {
+      "@odata.type": "#microsoft.graph.user",
+      "id": "00000000-0000-0000-0000-000000000012"
+    }
+  ]
+}

--- a/src/test/resources/groupMembersMixedTypes.json
+++ b/src/test/resources/groupMembersMixedTypes.json
@@ -1,0 +1,29 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#directoryObjects(id)",
+  "value": [
+    {
+      "@odata.type": "#microsoft.graph.user",
+      "id": "11111111-1111-1111-1111-111111111111"
+    },
+    {
+      "@odata.type": "#microsoft.graph.group",
+      "id": "22222222-2222-2222-2222-222222222222"
+    },
+    {
+      "@odata.type": "#microsoft.graph.user",
+      "id": "33333333-3333-3333-3333-333333333333"
+    },
+    {
+      "@odata.type": "#microsoft.graph.servicePrincipal",
+      "id": "44444444-4444-4444-4444-444444444444"
+    },
+    {
+      "@odata.type": "#microsoft.graph.device",
+      "id": "55555555-5555-5555-5555-555555555555"
+    },
+    {
+      "@odata.type": "#microsoft.graph.user",
+      "id": "66666666-6666-6666-6666-666666666666"
+    }
+  ]
+}

--- a/src/test/resources/userMinimalEntity.json
+++ b/src/test/resources/userMinimalEntity.json
@@ -1,0 +1,3 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users(mycustomid,name,email)/$entity"
+}

--- a/src/test/resources/userWithExtensionAttributes.json
+++ b/src/test/resources/userWithExtensionAttributes.json
@@ -1,0 +1,9 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users(id,displayName,userPrincipalName,extension_aaaaaaaabbbbccccddddeeeeeeeeeeee_mycustomid,extension_aaaaaaaabbbbccccddddeeeeeeeeeeee_name,extension_aaaaaaaabbbbccccddddeeeeeeeeeeee_email)/$entity",
+  "displayName": "John Doe",
+  "extension_aaaaaaaabbbbccccddddeeeeeeeeeeee_email": "john.doe@example.com",
+  "extension_aaaaaaaabbbbccccddddeeeeeeeeeeee_name": "John Doe",
+  "extension_aaaaaaaabbbbccccddddeeeeeeeeeeee_mycustomid": "anonymous-id-001",
+  "id": "11111111-1111-1111-1111-111111111111",
+  "userPrincipalName": "john.doe@example.com"
+}

--- a/src/test/resources/userWithMissingExtensionValue.json
+++ b/src/test/resources/userWithMissingExtensionValue.json
@@ -1,0 +1,9 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users(id,displayName,userPrincipalName,extension_aaaaaaaabbbbccccddddeeeeeeeeeeee_mycustomid,extension_aaaaaaaabbbbccccddddeeeeeeeeeeee_name,extension_aaaaaaaabbbbccccddddeeeeeeeeeeee_email)/$entity",
+  "displayName": "John Doe",
+  "extension_aaaaaaaabbbbccccddddeeeeeeeeeeee_email": "john.doe@example.com",
+  "extension_aaaaaaaabbbbccccddddeeeeeeeeeeee_name": "John Doe",
+  "extension_aaaaaaaabbbbccccddddeeeeeeeeeeee_mycustomid": null,
+  "id": "11111111-1111-1111-1111-111111111111",
+  "userPrincipalName": "john.doe@example.com"
+}

--- a/src/test/resources/userWithVanillaAttributes.json
+++ b/src/test/resources/userWithVanillaAttributes.json
@@ -1,0 +1,6 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users(mailNickname,displayName,mail)/$entity",
+  "displayName": "John Doe",
+  "mail": "john.doe@example.com",
+  "mailNickname": "john.doe"
+}


### PR DESCRIPTION
### Proposed changes

This pull request introduces support for Azure AD directory schema extension attributes in the Polarion user synchronization job, allowing custom user fields to be fetched from Microsoft Graph using either fully-qualified or automatically expanded names. The changes also add configuration options for these extensions, update documentation, and improve the integration testing setup.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
