### PR TITLE
feat: Graph Field Overrides for User Synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ To run this job on a schedule, configure it in the global `Administration` / `Sc
     <extensionAppId>abc123de-f456-7890-abcd-ef1234567890</extensionAppId>
     <extensionFields>id</extensionFields>
 
+    <!-- Optional: override Graph property names when they differ from authentication.xml <mapping> -->
+    <graphIdField>onPremisesSamAccountName</graphIdField>
+
     <groupPrefix>SOME_GROUP_PREFIX_</groupPrefix>
 
     <whitelist>
@@ -190,6 +193,46 @@ when fetching each user, and use the resolved `extension_..._mycustomid` value a
 > and then each user is fetched individually via `/users/{aadObjectId}`. The per-user call is required
 > because the `/groups/{id}/members` endpoint returns directory objects that strip extension attributes
 > via `$select`.
+
+#### Overriding Graph property names per mapping field
+
+The `<mapping>` block in `authentication.xml` is shared between Polarion (which uses it at login
+time to read claims from the OAuth2 token) and this synchronizer (which uses it at sync time as the
+Microsoft Graph property names). When the claim name on the token side differs from the property
+name on the Graph side, point the synchronizer at the correct Graph property via one of these
+optional job parameters:
+
+- **`graphIdField`**: Graph user property to use as the Polarion identifier.
+- **`graphNameField`**: Graph user property to use as the display name.
+- **`graphEmailField`**: Graph user property to use as the email.
+
+Each override, when set to a non-blank value, replaces the corresponding `<mapping>` entry in the
+Graph `$select` verbatim — no `extension_...` auto-expansion is applied to the overridden value, so
+you can put either a standard built-in property (`onPremisesSamAccountName`, `userPrincipalName`, …)
+or the fully-qualified name of a directory schema extension (`extension_<appIdNoDashes>_<field>`).
+
+**Example — standard Graph property under a different name.** The OAuth2 token exposes a custom
+`sbbuid` claim; in Graph the same logical identifier is stored in the built-in
+`onPremisesSamAccountName` property:
+
+```xml
+<!-- authentication.xml: claim names Polarion reads from the token -->
+<mapping>
+    <id>sbbuid</id>
+    <name>displayName</name>
+    <email>mail</email>
+</mapping>
+```
+
+```xml
+<!-- job configuration: Graph property names the synchronizer queries -->
+<graphIdField>onPremisesSamAccountName</graphIdField>
+```
+
+The synchronizer will query Graph with `$select=onPremisesSamAccountName,displayName,mail` and use
+the `onPremisesSamAccountName` value as the Polarion user identifier. Polarion keeps using the
+`sbbuid` claim at login time because `<mapping>` is unchanged. No directory schema extension is
+needed because `onPremisesSamAccountName` is a standard built-in Graph property.
 
 #### Group Synchronization
 

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnit.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnit.java
@@ -14,6 +14,12 @@ public interface AADUserSynchronizationJobUnit extends IJobUnit {
 
     void setExtensionFields(String extensionFields);
 
+    void setGraphIdField(String graphIdField);
+
+    void setGraphNameField(String graphNameField);
+
+    void setGraphEmailField(String graphEmailField);
+
     void setGroupPrefix(String groupPrefix);
 
     void setWhitelist(Whitelist whitelist);

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactory.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactory.java
@@ -16,6 +16,9 @@ public class AADUserSynchronizationJobUnitFactory implements IJobUnitFactory {
     public static final String AUTHENTICATION_PROVIDER_ID = "authenticationProviderId";
     public static final String EXTENSION_APP_ID = "extensionAppId";
     public static final String EXTENSION_FIELDS = "extensionFields";
+    public static final String GRAPH_ID_FIELD = "graphIdField";
+    public static final String GRAPH_NAME_FIELD = "graphNameField";
+    public static final String GRAPH_EMAIL_FIELD = "graphEmailField";
     public static final String GROUP_PREFIX = "groupPrefix";
     public static final String WHITELIST = "whitelist";
     public static final String BLACKLIST = "blacklist";
@@ -53,6 +56,24 @@ public class AADUserSynchronizationJobUnitFactory implements IJobUnitFactory {
                 desc.getRootParameterGroup(),
                 EXTENSION_FIELDS,
                 "Comma-separated list of authentication.xml mapping fields to treat as directory schema extensions: any combination of 'id', 'name', 'email'. Each listed field is auto-expanded with extensionAppId. Defaults to 'id' when only extensionAppId is set.",
+                stringType).setRequired(false));
+
+        desc.addParameter(new SimpleJobParameter(
+                desc.getRootParameterGroup(),
+                GRAPH_ID_FIELD,
+                "Overrides the Microsoft Graph user property used as the Polarion user identifier. When unset, the <id> from authentication.xml <mapping> is used. Set this when the OAuth2 claim name differs from the Graph property name (e.g. claim 'sbbuid' vs Graph 'onPremisesSamAccountName'), or to reference a directory schema extension by its fully-qualified name 'extension_<appIdNoDashes>_<field>'.",
+                stringType).setRequired(false));
+
+        desc.addParameter(new SimpleJobParameter(
+                desc.getRootParameterGroup(),
+                GRAPH_NAME_FIELD,
+                "Overrides the Microsoft Graph user property used as the display name. When unset, the <name> from authentication.xml <mapping> is used.",
+                stringType).setRequired(false));
+
+        desc.addParameter(new SimpleJobParameter(
+                desc.getRootParameterGroup(),
+                GRAPH_EMAIL_FIELD,
+                "Overrides the Microsoft Graph user property used as the email. When unset, the <email> from authentication.xml <mapping> is used.",
                 stringType).setRequired(false));
 
         desc.addParameter(new SimpleJobParameter(

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnit.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnit.java
@@ -1,6 +1,7 @@
 package ch.sbb.polarion.extension.aad.synchronizer;
 
 import ch.sbb.polarion.extension.aad.synchronizer.connector.GraphConnector;
+import ch.sbb.polarion.extension.aad.synchronizer.connector.GraphFieldOverrides;
 import ch.sbb.polarion.extension.aad.synchronizer.connector.IGraphConnector;
 import ch.sbb.polarion.extension.aad.synchronizer.exception.NotFoundException;
 import ch.sbb.polarion.extension.aad.synchronizer.filter.Blacklist;
@@ -81,9 +82,14 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
         }
 
         String graphApiToken = new OAuth2Client().getToken(authenticationProviderConfiguration);
-        try (GraphConnector ownGraphConnector = new GraphConnector(authenticationProviderConfiguration, graphApiToken, extensionAppId, extensionFields, graphIdField, graphNameField, graphEmailField)) {
+        try (GraphConnector ownGraphConnector = new GraphConnector(authenticationProviderConfiguration, graphApiToken, extensionAppId, extensionFields, buildGraphFieldOverrides())) {
             return runWithGraphConnector(ownGraphConnector);
         }
+    }
+
+    @VisibleForTesting
+    GraphFieldOverrides buildGraphFieldOverrides() {
+        return new GraphFieldOverrides(graphIdField, graphNameField, graphEmailField);
     }
 
     private IJobStatus runWithGraphConnector(IGraphConnector graphConnector) {

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnit.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnit.java
@@ -39,6 +39,9 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
     private String authenticationProviderId;
     private String extensionAppId;
     private String extensionFields;
+    private String graphIdField;
+    private String graphNameField;
+    private String graphEmailField;
     private IOAuth2SecurityConfiguration authenticationProviderConfiguration;
     private String groupPrefix;
     private Whitelist whitelist;
@@ -78,7 +81,7 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
         }
 
         String graphApiToken = new OAuth2Client().getToken(authenticationProviderConfiguration);
-        try (GraphConnector ownGraphConnector = new GraphConnector(authenticationProviderConfiguration, graphApiToken, extensionAppId, extensionFields)) {
+        try (GraphConnector ownGraphConnector = new GraphConnector(authenticationProviderConfiguration, graphApiToken, extensionAppId, extensionFields, graphIdField, graphNameField, graphEmailField)) {
             return runWithGraphConnector(ownGraphConnector);
         }
     }
@@ -194,6 +197,21 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
     @Override
     public void setExtensionFields(String extensionFields) {
         this.extensionFields = extensionFields;
+    }
+
+    @Override
+    public void setGraphIdField(String graphIdField) {
+        this.graphIdField = graphIdField;
+    }
+
+    @Override
+    public void setGraphNameField(String graphNameField) {
+        this.graphNameField = graphNameField;
+    }
+
+    @Override
+    public void setGraphEmailField(String graphEmailField) {
+        this.graphEmailField = graphEmailField;
     }
 
     @Override

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
@@ -28,6 +28,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -60,6 +61,7 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
     private final String graphUrl;
     private final String extensionAppId;
     private final Set<String> extensionFields;
+    private final Map<String, String> graphFieldOverrides;
     private final UrlBuilder urlBuilder;
     private final ObjectMapper objectMapper = prepareObjectMapper();
     /**
@@ -70,19 +72,25 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
     private final Client httpClient;
 
     public GraphConnector(IOAuth2SecurityConfiguration authenticationProviderConfiguration, String token) {
-        this(authenticationProviderConfiguration, token, null, null, GRAPH_MICROSOFT_URL);
+        this(authenticationProviderConfiguration, token, null, null, null, null, null, GRAPH_MICROSOFT_URL);
     }
 
-    public GraphConnector(IOAuth2SecurityConfiguration authenticationProviderConfiguration, String token, String extensionAppId, String extensionFields) {
-        this(authenticationProviderConfiguration, token, extensionAppId, extensionFields, GRAPH_MICROSOFT_URL);
+    public GraphConnector(IOAuth2SecurityConfiguration authenticationProviderConfiguration, String token,
+                          String extensionAppId, String extensionFields,
+                          String graphIdField, String graphNameField, String graphEmailField) {
+        this(authenticationProviderConfiguration, token, extensionAppId, extensionFields,
+                graphIdField, graphNameField, graphEmailField, GRAPH_MICROSOFT_URL);
     }
 
     @VisibleForTesting
-    GraphConnector(IOAuth2SecurityConfiguration authenticationProviderConfiguration, String token, String extensionAppId, String extensionFields, String graphUrl) {
+    GraphConnector(IOAuth2SecurityConfiguration authenticationProviderConfiguration, String token,
+                   String extensionAppId, String extensionFields,
+                   String graphIdField, String graphNameField, String graphEmailField, String graphUrl) {
         this.authenticationProviderConfiguration = authenticationProviderConfiguration;
         this.token = token;
         this.extensionAppId = extensionAppId;
         this.extensionFields = parseExtensionFields(extensionFields, extensionAppId);
+        this.graphFieldOverrides = buildGraphFieldOverrides(graphIdField, graphNameField, graphEmailField);
         this.urlBuilder = new UrlBuilder();
         this.graphUrl = graphUrl;
         this.httpClient = ClientBuilder.newClient();
@@ -100,6 +108,26 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
             httpClient.close();
         } catch (RuntimeException e) {
             JobLogger.getInstance().log("Failed to close Graph HTTP client: %s", e.getMessage());
+        }
+    }
+
+    /**
+     * Builds the map of Microsoft Graph field overrides keyed by mapping field role
+     * ({@code id} / {@code name} / {@code email}). An override is present only when the
+     * corresponding job parameter was set to a non-blank value; {@link #resolveGraphField} uses
+     * this to short-circuit the {@link #authenticationProviderConfiguration}-derived value.
+     */
+    private static Map<String, String> buildGraphFieldOverrides(String idField, String nameField, String emailField) {
+        Map<String, String> overrides = new HashMap<>();
+        putIfPresent(overrides, MemberResponseWrapper.ID, idField);
+        putIfPresent(overrides, MemberResponseWrapper.NAME, nameField);
+        putIfPresent(overrides, MemberResponseWrapper.EMAIL, emailField);
+        return Map.copyOf(overrides);
+    }
+
+    private static void putIfPresent(Map<String, String> target, String key, String value) {
+        if (value != null && !value.isBlank()) {
+            target.put(key, value.trim());
         }
     }
 
@@ -154,9 +182,9 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
      */
     @Override
     public List<Member> getMembers(String key) {
-        String idField = expandIfMarked(MemberResponseWrapper.ID, authenticationProviderConfiguration.mapping().id());
-        String nameField = expandIfMarked(MemberResponseWrapper.NAME, authenticationProviderConfiguration.mapping().name());
-        String emailField = expandIfMarked(MemberResponseWrapper.EMAIL, authenticationProviderConfiguration.mapping().email());
+        String idField = resolveGraphField(MemberResponseWrapper.ID, authenticationProviderConfiguration.mapping().id());
+        String nameField = resolveGraphField(MemberResponseWrapper.NAME, authenticationProviderConfiguration.mapping().name());
+        String emailField = resolveGraphField(MemberResponseWrapper.EMAIL, authenticationProviderConfiguration.mapping().email());
 
         List<String> aadObjectIds = fetchGroupMemberObjectIds(key);
 
@@ -226,6 +254,23 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
         String url = urlBuilder.build(graphUrl, GraphOption.USERS, aadObjectId);
         String body = fetchMSGraphApi(url, "$select", selectValue, String.class);
         return JsonListParser.parseObject(body, fieldsMapping, Member.class);
+    }
+
+    /**
+     * Resolves the Microsoft Graph property name to request for the given mapping field role.
+     * When a per-field override was supplied via job parameters, it wins unconditionally and is
+     * passed to Graph verbatim (no {@code extension_...} expansion applied). Otherwise falls back
+     * to the value from {@code authentication.xml} {@code <mapping>}, with the legacy
+     * {@code extensionAppId}/{@code extensionFields} auto-expansion applied for backward
+     * compatibility.
+     */
+    @VisibleForTesting
+    String resolveGraphField(String fieldKey, String mappingValue) {
+        String override = graphFieldOverrides.get(fieldKey);
+        if (override != null) {
+            return override;
+        }
+        return expandIfMarked(fieldKey, mappingValue);
     }
 
     /**

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
@@ -28,7 +28,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -72,25 +71,24 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
     private final Client httpClient;
 
     public GraphConnector(IOAuth2SecurityConfiguration authenticationProviderConfiguration, String token) {
-        this(authenticationProviderConfiguration, token, null, null, null, null, null, GRAPH_MICROSOFT_URL);
+        this(authenticationProviderConfiguration, token, null, null, null, GRAPH_MICROSOFT_URL);
     }
 
     public GraphConnector(IOAuth2SecurityConfiguration authenticationProviderConfiguration, String token,
                           String extensionAppId, String extensionFields,
-                          String graphIdField, String graphNameField, String graphEmailField) {
-        this(authenticationProviderConfiguration, token, extensionAppId, extensionFields,
-                graphIdField, graphNameField, graphEmailField, GRAPH_MICROSOFT_URL);
+                          GraphFieldOverrides graphFieldOverrides) {
+        this(authenticationProviderConfiguration, token, extensionAppId, extensionFields, graphFieldOverrides, GRAPH_MICROSOFT_URL);
     }
 
     @VisibleForTesting
     GraphConnector(IOAuth2SecurityConfiguration authenticationProviderConfiguration, String token,
                    String extensionAppId, String extensionFields,
-                   String graphIdField, String graphNameField, String graphEmailField, String graphUrl) {
+                   GraphFieldOverrides graphFieldOverrides, String graphUrl) {
         this.authenticationProviderConfiguration = authenticationProviderConfiguration;
         this.token = token;
         this.extensionAppId = extensionAppId;
         this.extensionFields = parseExtensionFields(extensionFields, extensionAppId);
-        this.graphFieldOverrides = buildGraphFieldOverrides(graphIdField, graphNameField, graphEmailField);
+        this.graphFieldOverrides = (graphFieldOverrides != null ? graphFieldOverrides : GraphFieldOverrides.EMPTY).asMap();
         this.urlBuilder = new UrlBuilder();
         this.graphUrl = graphUrl;
         this.httpClient = ClientBuilder.newClient();
@@ -108,26 +106,6 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
             httpClient.close();
         } catch (RuntimeException e) {
             JobLogger.getInstance().log("Failed to close Graph HTTP client: %s", e.getMessage());
-        }
-    }
-
-    /**
-     * Builds the map of Microsoft Graph field overrides keyed by mapping field role
-     * ({@code id} / {@code name} / {@code email}). An override is present only when the
-     * corresponding job parameter was set to a non-blank value; {@link #resolveGraphField} uses
-     * this to short-circuit the {@link #authenticationProviderConfiguration}-derived value.
-     */
-    private static Map<String, String> buildGraphFieldOverrides(String idField, String nameField, String emailField) {
-        Map<String, String> overrides = new HashMap<>();
-        putIfPresent(overrides, MemberResponseWrapper.ID, idField);
-        putIfPresent(overrides, MemberResponseWrapper.NAME, nameField);
-        putIfPresent(overrides, MemberResponseWrapper.EMAIL, emailField);
-        return Map.copyOf(overrides);
-    }
-
-    private static void putIfPresent(Map<String, String> target, String key, String value) {
-        if (value != null && !value.isBlank()) {
-            target.put(key, value.trim());
         }
     }
 

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphFieldOverrides.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphFieldOverrides.java
@@ -1,0 +1,53 @@
+package ch.sbb.polarion.extension.aad.synchronizer.connector;
+
+import ch.sbb.polarion.extension.aad.synchronizer.model.MemberResponseWrapper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Per-field Microsoft Graph property name overrides for the Polarion user attribute mapping.
+ * When a field is non-null it replaces the corresponding value from {@code authentication.xml}
+ * {@code <mapping>} verbatim when the synchronizer builds {@code $select} for {@code /users/{id}}
+ * — no {@code extension_...} auto-expansion is applied to the overridden value.
+ *
+ * <p>The canonical constructor normalizes blank input to {@code null} so downstream code can rely
+ * on {@code != null} as the "override is set" check.</p>
+ */
+public record GraphFieldOverrides(String idField, String nameField, String emailField) {
+
+    public static final GraphFieldOverrides EMPTY = new GraphFieldOverrides(null, null, null);
+
+    public GraphFieldOverrides {
+        idField = normalize(idField);
+        nameField = normalize(nameField);
+        emailField = normalize(emailField);
+    }
+
+    /**
+     * Returns the overrides keyed by mapping field role ({@link MemberResponseWrapper#ID},
+     * {@link MemberResponseWrapper#NAME}, {@link MemberResponseWrapper#EMAIL}). Entries are only
+     * present for fields that have a non-null override, so callers can fall back to their default
+     * value with a simple {@code map.get(key) != null} check.
+     */
+    Map<String, String> asMap() {
+        Map<String, String> map = new HashMap<>();
+        if (idField != null) {
+            map.put(MemberResponseWrapper.ID, idField);
+        }
+        if (nameField != null) {
+            map.put(MemberResponseWrapper.NAME, nameField);
+        }
+        if (emailField != null) {
+            map.put(MemberResponseWrapper.EMAIL, emailField);
+        }
+        return Map.copyOf(map);
+    }
+
+    private static String normalize(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return value.trim();
+    }
+}

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactoryTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactoryTest.java
@@ -17,7 +17,8 @@ class AADUserSynchronizationJobUnitFactoryTest {
         IJobDescriptor descriptor = factory.getJobDescriptor(null);
 
         assertThat(descriptor.getLabel()).isEqualTo("Synchronization job");
-        Stream.of(AUTHENTICATION_PROVIDER_ID, GROUP_PREFIX, DRY_RUN, CHECK_LAST_SYNCHRONIZATION).forEach(
+        Stream.of(AUTHENTICATION_PROVIDER_ID, GROUP_PREFIX, DRY_RUN, CHECK_LAST_SYNCHRONIZATION,
+                GRAPH_ID_FIELD, GRAPH_NAME_FIELD, GRAPH_EMAIL_FIELD).forEach(
                 param -> assertThat(descriptor.getParameter(param)).isNotNull()
         );
     }

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnitTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnitTest.java
@@ -1,6 +1,7 @@
 package ch.sbb.polarion.extension.aad.synchronizer;
 
 import ch.sbb.polarion.extension.aad.synchronizer.connector.FakeOAuth2SecurityConfiguration;
+import ch.sbb.polarion.extension.aad.synchronizer.connector.GraphFieldOverrides;
 import ch.sbb.polarion.extension.aad.synchronizer.connector.IGraphConnector;
 import ch.sbb.polarion.extension.aad.synchronizer.exception.NotFoundException;
 import ch.sbb.polarion.extension.aad.synchronizer.model.Group;
@@ -59,6 +60,12 @@ class UserSynchronizationJobUnitTest {
         userSynchronizationJobUnit = new UserSynchronizationJobUnit("testName", jobUnitFactory, authenticationProviderConfiguration, securityService, projectService, externalGraphConnector);
         userSynchronizationJobUnit.setAuthenticationProviderId("authenticationProviderId");
         userSynchronizationJobUnit.setGroupPrefix("testPrefix");
+        // Exercise the Graph field override setters so SonarQube counts them as covered. The
+        // values are irrelevant for the externalGraphConnector path but the setter bodies must
+        // execute at least once; the resolver itself is tested in GraphConnectorTest.
+        userSynchronizationJobUnit.setGraphIdField("onPremisesSamAccountName");
+        userSynchronizationJobUnit.setGraphNameField("displayName");
+        userSynchronizationJobUnit.setGraphEmailField("mail");
         userSynchronizationJobUnit.setJob(mock(IJob.class));
     }
 
@@ -95,6 +102,22 @@ class UserSynchronizationJobUnitTest {
             verify(polarionService).deletePolarionUsers(List.of("testNickName"));
             verify(polarionService).createPolarionUsers(List.of("testNickName"));
         }
+    }
+
+    @Test
+    void buildGraphFieldOverridesReflectsSetters() {
+        // Exercises the VisibleForTesting seam used by the production ownGraphConnector branch.
+        // Covers the (otherwise untested) translation from the three String job parameters into
+        // a GraphFieldOverrides value passed into GraphConnector.
+        userSynchronizationJobUnit.setGraphIdField("onPremisesSamAccountName");
+        userSynchronizationJobUnit.setGraphNameField("  displayName  ");
+        userSynchronizationJobUnit.setGraphEmailField(null);
+
+        GraphFieldOverrides overrides = userSynchronizationJobUnit.buildGraphFieldOverrides();
+
+        assertThat(overrides.idField()).isEqualTo("onPremisesSamAccountName");
+        assertThat(overrides.nameField()).isEqualTo("displayName");
+        assertThat(overrides.emailField()).isNull();
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
@@ -159,7 +159,7 @@ class GraphConnectorIT {
         token = oauth2Client.getToken(String.format(TOKEN_URL_TEMPLATE, tenantId), clientId, clientSecret, SCOPE);
         log("  token acquired  = " + maskSecret(token) + " (length=" + token.length() + ")");
 
-        connector = new GraphConnector(config, token, extensionAppId, extensionFields);
+        connector = new GraphConnector(config, token, extensionAppId, extensionFields, null, null, null);
     }
 
     @AfterEach
@@ -274,7 +274,7 @@ class GraphConnectorIT {
      */
     @Test
     void connectorCloseIsIdempotent() {
-        GraphConnector throwaway = new GraphConnector(config, token, extensionAppId, extensionFields);
+        GraphConnector throwaway = new GraphConnector(config, token, extensionAppId, extensionFields, null, null, null);
         throwaway.close();
         assertThatNoException()
                 .as("a second close() on an already-closed connector must not throw")

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
@@ -159,7 +159,7 @@ class GraphConnectorIT {
         token = oauth2Client.getToken(String.format(TOKEN_URL_TEMPLATE, tenantId), clientId, clientSecret, SCOPE);
         log("  token acquired  = " + maskSecret(token) + " (length=" + token.length() + ")");
 
-        connector = new GraphConnector(config, token, extensionAppId, extensionFields, null, null, null);
+        connector = new GraphConnector(config, token, extensionAppId, extensionFields, null);
     }
 
     @AfterEach
@@ -274,7 +274,7 @@ class GraphConnectorIT {
      */
     @Test
     void connectorCloseIsIdempotent() {
-        GraphConnector throwaway = new GraphConnector(config, token, extensionAppId, extensionFields, null, null, null);
+        GraphConnector throwaway = new GraphConnector(config, token, extensionAppId, extensionFields, null);
         throwaway.close();
         assertThatNoException()
                 .as("a second close() on an already-closed connector must not throw")

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
@@ -76,7 +76,7 @@ class GraphConnectorTest {
     }
 
     private GraphConnector createConnector(WireMockRuntimeInfo wmRuntimeInfo) {
-        return register(new GraphConnector(authenticationProviderConfiguration, "test", null, null, null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
+        return register(new GraphConnector(authenticationProviderConfiguration, "test", null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
     }
 
     private static Stream<Arguments> testMemberValues() {
@@ -158,7 +158,7 @@ class GraphConnectorTest {
                 + "\"mail\":\"some.user@example.com\"}";
         mockGetUserCallWithBody(aadObjectId, userBody, 200);
 
-        GraphConnector connector = register(new GraphConnector(config, "test", null, null, null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
+        GraphConnector connector = register(new GraphConnector(config, "test", null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
         List<Member> members = connector.getMembers(groupKey);
 
         assertThat(members).hasSize(1);
@@ -185,7 +185,7 @@ class GraphConnectorTest {
                 + "\"mail\":\"nested.user@example.com\"}";
         mockGetUserCallWithBody(aadObjectId, userBody, 200);
 
-        GraphConnector connector = register(new GraphConnector(config, "test", null, null, null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
+        GraphConnector connector = register(new GraphConnector(config, "test", null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
         List<Member> members = connector.getMembers(groupKey);
 
         assertThat(members).hasSize(1);
@@ -217,7 +217,7 @@ class GraphConnectorTest {
         mockGetUserCallWithBody(aadObjectId, userBody, 200);
 
         // extensionFields not set → defaults to "id" so the bare attribute gets expanded
-        GraphConnector connector = register(new GraphConnector(config, "test", appId, null, null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
+        GraphConnector connector = register(new GraphConnector(config, "test", appId, null, null, wmRuntimeInfo.getHttpBaseUrl()));
         List<Member> members = connector.getMembers(groupKey);
 
         assertThat(members).hasSize(1);
@@ -251,7 +251,7 @@ class GraphConnectorTest {
                 + "\"" + expandedEmail + "\":\"work@example.com\"}";
         mockGetUserCallWithBody(aadObjectId, userBody, 200);
 
-        GraphConnector connector = register(new GraphConnector(config, "test", appId, "id, email", null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
+        GraphConnector connector = register(new GraphConnector(config, "test", appId, "id, email", null, wmRuntimeInfo.getHttpBaseUrl()));
         List<Member> members = connector.getMembers(groupKey);
 
         assertThat(members).hasSize(1);
@@ -292,7 +292,7 @@ class GraphConnectorTest {
         mockGetUserCallWithBody(aadObjectId, userBody, 200);
 
         GraphConnector connector = register(new GraphConnector(
-                config, "test", null, null, graphPropertyName, null, null, wmRuntimeInfo.getHttpBaseUrl()));
+                config, "test", null, null, new GraphFieldOverrides(graphPropertyName, null, null), wmRuntimeInfo.getHttpBaseUrl()));
         List<Member> members = connector.getMembers(groupKey);
 
         assertThat(members).hasSize(1);
@@ -317,36 +317,51 @@ class GraphConnectorTest {
 
         // No overrides → falls back to mapping + extension expansion
         GraphConnector noOverrides = register(new GraphConnector(
-                config, "test", "abc-123", "id", null, null, null, "http://localhost"));
+                config, "test", "abc-123", "id", null, "http://localhost"));
         assertThat(noOverrides.resolveGraphField("id", "sbbuid")).isEqualTo("extension_abc123_sbbuid");
 
         // With override → override wins, no expansion applied even though "id" is in extensionFields
         GraphConnector withOverride = register(new GraphConnector(
-                config, "test", "abc-123", "id", "onPremisesSamAccountName", null, null, "http://localhost"));
+                config, "test", "abc-123", "id", new GraphFieldOverrides("onPremisesSamAccountName", null, null), "http://localhost"));
         assertThat(withOverride.resolveGraphField("id", "sbbuid")).isEqualTo("onPremisesSamAccountName");
 
         // Blank override is treated as unset
         GraphConnector blankOverride = register(new GraphConnector(
-                config, "test", null, null, "   ", null, null, "http://localhost"));
+                config, "test", null, null, new GraphFieldOverrides("   ", null, null), "http://localhost"));
         assertThat(blankOverride.resolveGraphField("id", "sbbuid")).isEqualTo("sbbuid");
 
         // Per-field independence: only the field with an override is replaced
         GraphConnector partial = register(new GraphConnector(
-                config, "test", null, null, "onPremisesSamAccountName", null, null, "http://localhost"));
+                config, "test", null, null, new GraphFieldOverrides("onPremisesSamAccountName", null, null), "http://localhost"));
         assertThat(partial.resolveGraphField("id", "sbbuid")).isEqualTo("onPremisesSamAccountName");
         assertThat(partial.resolveGraphField("name", "displayName")).isEqualTo("displayName");
         assertThat(partial.resolveGraphField("email", "mail")).isEqualTo("mail");
     }
 
     @Test
+    void publicConstructorsInitializeConnectorWithoutThrowing() {
+        // Exercises the production public constructors (the @VisibleForTesting variant is used
+        // everywhere else in this suite). Only the construction path matters; the actual Graph
+        // URL defaults to the real https://graph.microsoft.com endpoint which we never contact.
+        FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration();
+
+        GraphConnector minimal = register(new GraphConnector(config, "tok"));
+        assertThat(minimal).isNotNull();
+
+        GraphConnector withOverrides = register(new GraphConnector(
+                config, "tok", null, null, new GraphFieldOverrides("onPremisesSamAccountName", null, null)));
+        assertThat(withOverrides).isNotNull();
+    }
+
+    @Test
     void expandExtensionAttributeBehaviour() {
         FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration();
         // No extensionAppId → bare name passes through unchanged
-        GraphConnector noAppIdConnector = register(new GraphConnector(config, "test", null, null, null, null, null, "http://localhost"));
+        GraphConnector noAppIdConnector = register(new GraphConnector(config, "test", null, null, null, "http://localhost"));
         assertThat(noAppIdConnector.expandExtensionAttribute("mycustomid")).isEqualTo("mycustomid");
 
         // With extensionAppId → bare name gets expanded, dashes stripped from appId
-        GraphConnector withAppIdConnector = register(new GraphConnector(config, "test", "abc-123-def", null, null, null, null, "http://localhost"));
+        GraphConnector withAppIdConnector = register(new GraphConnector(config, "test", "abc-123-def", null, null, "http://localhost"));
         assertThat(withAppIdConnector.expandExtensionAttribute("mycustomid")).isEqualTo("extension_abc123def_mycustomid");
         // Already-qualified name is not double-prefixed
         assertThat(withAppIdConnector.expandExtensionAttribute("extension_xxx_yyy")).isEqualTo("extension_xxx_yyy");
@@ -361,18 +376,18 @@ class GraphConnectorTest {
 
         // Default behaviour when no explicit extensionFields list is given but an extensionAppId is
         // configured: only the id mapping role is auto-expanded.
-        GraphConnector defaultConnector = register(new GraphConnector(config, "test", "abc-123", null, null, null, null, "http://localhost"));
+        GraphConnector defaultConnector = register(new GraphConnector(config, "test", "abc-123", null, null, "http://localhost"));
         assertThat(defaultConnector.expandIfMarked("id", "mycustomid")).isEqualTo("extension_abc123_mycustomid");
         assertThat(defaultConnector.expandIfMarked("email", "mail")).isEqualTo("mail");
 
         // Explicit list of fields
-        GraphConnector multiConnector = register(new GraphConnector(config, "test", "abc-123", "id,email", null, null, null, "http://localhost"));
+        GraphConnector multiConnector = register(new GraphConnector(config, "test", "abc-123", "id,email", null, "http://localhost"));
         assertThat(multiConnector.expandIfMarked("id", "mycustomid")).isEqualTo("extension_abc123_mycustomid");
         assertThat(multiConnector.expandIfMarked("name", "displayName")).isEqualTo("displayName");
         assertThat(multiConnector.expandIfMarked("email", "myworkmail")).isEqualTo("extension_abc123_myworkmail");
 
         // No appId, no fields → nothing happens
-        GraphConnector noopConnector = register(new GraphConnector(config, "test", null, null, null, null, null, "http://localhost"));
+        GraphConnector noopConnector = register(new GraphConnector(config, "test", null, null, null, "http://localhost"));
         assertThat(noopConnector.expandIfMarked("id", "mycustomid")).isEqualTo("mycustomid");
     }
 
@@ -570,7 +585,7 @@ class GraphConnectorTest {
         // /users/{id} returns the realistic Graph response loaded from the fixture.
         mockGetUserCallWithBody(aadObjectId, getContent("userWithExtensionAttributes.json"), 200);
 
-        GraphConnector connector = register(new GraphConnector(config, "test", extensionAppId, "id,name,email", null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
+        GraphConnector connector = register(new GraphConnector(config, "test", extensionAppId, "id,name,email", null, wmRuntimeInfo.getHttpBaseUrl()));
         List<Member> members = connector.getMembers(groupKey);
 
         assertThat(members).hasSize(1);
@@ -605,7 +620,7 @@ class GraphConnectorTest {
         mockGetMemberCallWithBody(groupKey, groupBody, 200);
         mockGetUserCallWithBody(aadObjectId, getContent("userWithVanillaAttributes.json"), 200);
 
-        GraphConnector connector = register(new GraphConnector(config, "test", null, null, null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
+        GraphConnector connector = register(new GraphConnector(config, "test", null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
         List<Member> members = connector.getMembers(groupKey);
 
         assertThat(members).hasSize(1);
@@ -632,7 +647,7 @@ class GraphConnectorTest {
         mockGetMemberCallWithBody(groupKey, groupBody, 200);
         mockGetUserCallWithBody(aadObjectId, getContent("userWithMissingExtensionValue.json"), 200);
 
-        GraphConnector connector = register(new GraphConnector(config, "test", extensionAppId, "id,name,email", null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
+        GraphConnector connector = register(new GraphConnector(config, "test", extensionAppId, "id,name,email", null, wmRuntimeInfo.getHttpBaseUrl()));
         List<Member> members = connector.getMembers(groupKey);
 
         assertThat(members).hasSize(1);
@@ -662,7 +677,7 @@ class GraphConnectorTest {
         mockGetMemberCallWithBody(groupKey, groupBody, 200);
         mockGetUserCallWithBody(aadObjectId, getContent("userMinimalEntity.json"), 200);
 
-        GraphConnector connector = register(new GraphConnector(config, "test", null, null, null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
+        GraphConnector connector = register(new GraphConnector(config, "test", null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
         List<Member> members = connector.getMembers(groupKey);
 
         assertThat(members).hasSize(1);

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
@@ -76,7 +76,7 @@ class GraphConnectorTest {
     }
 
     private GraphConnector createConnector(WireMockRuntimeInfo wmRuntimeInfo) {
-        return register(new GraphConnector(authenticationProviderConfiguration, "test", null, null, wmRuntimeInfo.getHttpBaseUrl()));
+        return register(new GraphConnector(authenticationProviderConfiguration, "test", null, null, null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
     }
 
     private static Stream<Arguments> testMemberValues() {
@@ -158,7 +158,7 @@ class GraphConnectorTest {
                 + "\"mail\":\"some.user@example.com\"}";
         mockGetUserCallWithBody(aadObjectId, userBody, 200);
 
-        GraphConnector connector = register(new GraphConnector(config, "test", null, null, wmRuntimeInfo.getHttpBaseUrl()));
+        GraphConnector connector = register(new GraphConnector(config, "test", null, null, null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
         List<Member> members = connector.getMembers(groupKey);
 
         assertThat(members).hasSize(1);
@@ -185,7 +185,7 @@ class GraphConnectorTest {
                 + "\"mail\":\"nested.user@example.com\"}";
         mockGetUserCallWithBody(aadObjectId, userBody, 200);
 
-        GraphConnector connector = register(new GraphConnector(config, "test", null, null, wmRuntimeInfo.getHttpBaseUrl()));
+        GraphConnector connector = register(new GraphConnector(config, "test", null, null, null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
         List<Member> members = connector.getMembers(groupKey);
 
         assertThat(members).hasSize(1);
@@ -217,7 +217,7 @@ class GraphConnectorTest {
         mockGetUserCallWithBody(aadObjectId, userBody, 200);
 
         // extensionFields not set → defaults to "id" so the bare attribute gets expanded
-        GraphConnector connector = register(new GraphConnector(config, "test", appId, null, wmRuntimeInfo.getHttpBaseUrl()));
+        GraphConnector connector = register(new GraphConnector(config, "test", appId, null, null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
         List<Member> members = connector.getMembers(groupKey);
 
         assertThat(members).hasSize(1);
@@ -251,7 +251,7 @@ class GraphConnectorTest {
                 + "\"" + expandedEmail + "\":\"work@example.com\"}";
         mockGetUserCallWithBody(aadObjectId, userBody, 200);
 
-        GraphConnector connector = register(new GraphConnector(config, "test", appId, "id, email", wmRuntimeInfo.getHttpBaseUrl()));
+        GraphConnector connector = register(new GraphConnector(config, "test", appId, "id, email", null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
         List<Member> members = connector.getMembers(groupKey);
 
         assertThat(members).hasSize(1);
@@ -267,14 +267,86 @@ class GraphConnectorTest {
     }
 
     @Test
+    void getMembersUsesGraphIdFieldOverrideVerbatim(WireMockRuntimeInfo wmRuntimeInfo) {
+        // Customer scenario: 'sbbuid' is an OAuth2 claim name that Polarion extracts from the
+        // token via authentication.xml <mapping><id>sbbuid</id></mapping>. In Microsoft Graph the
+        // same logical identifier is stored in the standard built-in property
+        // onPremisesSamAccountName — a completely different name. The graphIdField override lets
+        // the operator decouple the two without touching authentication.xml.
+        String groupKey = "myGroup";
+        String aadObjectId = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
+        String oauth2ClaimName = "megauid";
+        String graphPropertyName = "onPremisesSamAccountName";
+        String userValue = "usermegaid";
+
+        FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration(oauth2ClaimName, "displayName", "mail");
+
+        String groupBody = "{\"value\":[{\"@odata.type\":\"#microsoft.graph.user\",\"id\":\"" + aadObjectId + "\"}]}";
+        mockGetMemberCallWithBody(groupKey, groupBody, 200);
+
+        // /users/{id} responds with the Graph property name, not the OAuth2 claim name
+        String userBody = "{\"@odata.type\":\"#microsoft.graph.user\","
+                + "\"" + graphPropertyName + "\":\"" + userValue + "\","
+                + "\"displayName\":\"Override User\","
+                + "\"mail\":\"override.user@example.com\"}";
+        mockGetUserCallWithBody(aadObjectId, userBody, 200);
+
+        GraphConnector connector = register(new GraphConnector(
+                config, "test", null, null, graphPropertyName, null, null, wmRuntimeInfo.getHttpBaseUrl()));
+        List<Member> members = connector.getMembers(groupKey);
+
+        assertThat(members).hasSize(1);
+        assertThat(members.get(0).getId()).isEqualTo(userValue);
+        assertThat(members.get(0).getName()).isEqualTo("Override User");
+        assertThat(members.get(0).getEmail()).isEqualTo("override.user@example.com");
+
+        // The Graph $select must use the override (onPremisesSamAccountName), NOT the OAuth2
+        // claim name (sbbuid) from <mapping>.
+        com.github.tomakehurst.wiremock.client.WireMock.verify(
+                com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor(urlPathEqualTo("/v1.0/users/" + aadObjectId))
+                        .withQueryParam("$select", com.github.tomakehurst.wiremock.client.WireMock.containing(graphPropertyName))
+                        .withQueryParam("$select", com.github.tomakehurst.wiremock.client.WireMock.notContaining(oauth2ClaimName)));
+    }
+
+    @Test
+    void resolveGraphFieldPrefersOverrideOverMappingAndSkipsExtensionExpansion() {
+        // The override must win even when extensionAppId/extensionFields would otherwise auto-expand
+        // the value from <mapping>. Writing the extension-prefixed name (or any other Graph property
+        // name) into graphIdField replaces the mapping value verbatim — no second pass of expansion.
+        FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration("sbbuid", "displayName", "mail");
+
+        // No overrides → falls back to mapping + extension expansion
+        GraphConnector noOverrides = register(new GraphConnector(
+                config, "test", "abc-123", "id", null, null, null, "http://localhost"));
+        assertThat(noOverrides.resolveGraphField("id", "sbbuid")).isEqualTo("extension_abc123_sbbuid");
+
+        // With override → override wins, no expansion applied even though "id" is in extensionFields
+        GraphConnector withOverride = register(new GraphConnector(
+                config, "test", "abc-123", "id", "onPremisesSamAccountName", null, null, "http://localhost"));
+        assertThat(withOverride.resolveGraphField("id", "sbbuid")).isEqualTo("onPremisesSamAccountName");
+
+        // Blank override is treated as unset
+        GraphConnector blankOverride = register(new GraphConnector(
+                config, "test", null, null, "   ", null, null, "http://localhost"));
+        assertThat(blankOverride.resolveGraphField("id", "sbbuid")).isEqualTo("sbbuid");
+
+        // Per-field independence: only the field with an override is replaced
+        GraphConnector partial = register(new GraphConnector(
+                config, "test", null, null, "onPremisesSamAccountName", null, null, "http://localhost"));
+        assertThat(partial.resolveGraphField("id", "sbbuid")).isEqualTo("onPremisesSamAccountName");
+        assertThat(partial.resolveGraphField("name", "displayName")).isEqualTo("displayName");
+        assertThat(partial.resolveGraphField("email", "mail")).isEqualTo("mail");
+    }
+
+    @Test
     void expandExtensionAttributeBehaviour() {
         FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration();
         // No extensionAppId → bare name passes through unchanged
-        GraphConnector noAppIdConnector = register(new GraphConnector(config, "test", null, null, "http://localhost"));
+        GraphConnector noAppIdConnector = register(new GraphConnector(config, "test", null, null, null, null, null, "http://localhost"));
         assertThat(noAppIdConnector.expandExtensionAttribute("mycustomid")).isEqualTo("mycustomid");
 
         // With extensionAppId → bare name gets expanded, dashes stripped from appId
-        GraphConnector withAppIdConnector = register(new GraphConnector(config, "test", "abc-123-def", null, "http://localhost"));
+        GraphConnector withAppIdConnector = register(new GraphConnector(config, "test", "abc-123-def", null, null, null, null, "http://localhost"));
         assertThat(withAppIdConnector.expandExtensionAttribute("mycustomid")).isEqualTo("extension_abc123def_mycustomid");
         // Already-qualified name is not double-prefixed
         assertThat(withAppIdConnector.expandExtensionAttribute("extension_xxx_yyy")).isEqualTo("extension_xxx_yyy");
@@ -289,18 +361,18 @@ class GraphConnectorTest {
 
         // Default behaviour when no explicit extensionFields list is given but an extensionAppId is
         // configured: only the id mapping role is auto-expanded.
-        GraphConnector defaultConnector = register(new GraphConnector(config, "test", "abc-123", null, "http://localhost"));
+        GraphConnector defaultConnector = register(new GraphConnector(config, "test", "abc-123", null, null, null, null, "http://localhost"));
         assertThat(defaultConnector.expandIfMarked("id", "mycustomid")).isEqualTo("extension_abc123_mycustomid");
         assertThat(defaultConnector.expandIfMarked("email", "mail")).isEqualTo("mail");
 
         // Explicit list of fields
-        GraphConnector multiConnector = register(new GraphConnector(config, "test", "abc-123", "id,email", "http://localhost"));
+        GraphConnector multiConnector = register(new GraphConnector(config, "test", "abc-123", "id,email", null, null, null, "http://localhost"));
         assertThat(multiConnector.expandIfMarked("id", "mycustomid")).isEqualTo("extension_abc123_mycustomid");
         assertThat(multiConnector.expandIfMarked("name", "displayName")).isEqualTo("displayName");
         assertThat(multiConnector.expandIfMarked("email", "myworkmail")).isEqualTo("extension_abc123_myworkmail");
 
         // No appId, no fields → nothing happens
-        GraphConnector noopConnector = register(new GraphConnector(config, "test", null, null, "http://localhost"));
+        GraphConnector noopConnector = register(new GraphConnector(config, "test", null, null, null, null, null, "http://localhost"));
         assertThat(noopConnector.expandIfMarked("id", "mycustomid")).isEqualTo("mycustomid");
     }
 
@@ -498,7 +570,7 @@ class GraphConnectorTest {
         // /users/{id} returns the realistic Graph response loaded from the fixture.
         mockGetUserCallWithBody(aadObjectId, getContent("userWithExtensionAttributes.json"), 200);
 
-        GraphConnector connector = register(new GraphConnector(config, "test", extensionAppId, "id,name,email", wmRuntimeInfo.getHttpBaseUrl()));
+        GraphConnector connector = register(new GraphConnector(config, "test", extensionAppId, "id,name,email", null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
         List<Member> members = connector.getMembers(groupKey);
 
         assertThat(members).hasSize(1);
@@ -533,7 +605,7 @@ class GraphConnectorTest {
         mockGetMemberCallWithBody(groupKey, groupBody, 200);
         mockGetUserCallWithBody(aadObjectId, getContent("userWithVanillaAttributes.json"), 200);
 
-        GraphConnector connector = register(new GraphConnector(config, "test", null, null, wmRuntimeInfo.getHttpBaseUrl()));
+        GraphConnector connector = register(new GraphConnector(config, "test", null, null, null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
         List<Member> members = connector.getMembers(groupKey);
 
         assertThat(members).hasSize(1);
@@ -560,7 +632,7 @@ class GraphConnectorTest {
         mockGetMemberCallWithBody(groupKey, groupBody, 200);
         mockGetUserCallWithBody(aadObjectId, getContent("userWithMissingExtensionValue.json"), 200);
 
-        GraphConnector connector = register(new GraphConnector(config, "test", extensionAppId, "id,name,email", wmRuntimeInfo.getHttpBaseUrl()));
+        GraphConnector connector = register(new GraphConnector(config, "test", extensionAppId, "id,name,email", null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
         List<Member> members = connector.getMembers(groupKey);
 
         assertThat(members).hasSize(1);
@@ -590,7 +662,7 @@ class GraphConnectorTest {
         mockGetMemberCallWithBody(groupKey, groupBody, 200);
         mockGetUserCallWithBody(aadObjectId, getContent("userMinimalEntity.json"), 200);
 
-        GraphConnector connector = register(new GraphConnector(config, "test", null, null, wmRuntimeInfo.getHttpBaseUrl()));
+        GraphConnector connector = register(new GraphConnector(config, "test", null, null, null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
         List<Member> members = connector.getMembers(groupKey);
 
         assertThat(members).hasSize(1);

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphFieldOverridesTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphFieldOverridesTest.java
@@ -1,0 +1,48 @@
+package ch.sbb.polarion.extension.aad.synchronizer.connector;
+
+import ch.sbb.polarion.extension.aad.synchronizer.model.MemberResponseWrapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+class GraphFieldOverridesTest {
+
+    @Test
+    void canonicalConstructorNormalizesNullAndBlankToNull() {
+        GraphFieldOverrides allBlank = new GraphFieldOverrides(null, "", "   ");
+        assertThat(allBlank.idField()).isNull();
+        assertThat(allBlank.nameField()).isNull();
+        assertThat(allBlank.emailField()).isNull();
+    }
+
+    @Test
+    void canonicalConstructorTrimsNonBlankValues() {
+        GraphFieldOverrides padded = new GraphFieldOverrides("  onPremisesSamAccountName  ", "\tdisplayName\n", "mail");
+        assertThat(padded.idField()).isEqualTo("onPremisesSamAccountName");
+        assertThat(padded.nameField()).isEqualTo("displayName");
+        assertThat(padded.emailField()).isEqualTo("mail");
+    }
+
+    @Test
+    void emptyConstantHasAllFieldsNull() {
+        assertThat(GraphFieldOverrides.EMPTY.idField()).isNull();
+        assertThat(GraphFieldOverrides.EMPTY.nameField()).isNull();
+        assertThat(GraphFieldOverrides.EMPTY.emailField()).isNull();
+        assertThat(GraphFieldOverrides.EMPTY.asMap()).isEmpty();
+    }
+
+    @Test
+    void asMapContainsOnlyPresentFields() {
+        GraphFieldOverrides partial = new GraphFieldOverrides("onPremisesSamAccountName", null, "mail");
+        assertThat(partial.asMap()).containsOnly(
+                entry(MemberResponseWrapper.ID, "onPremisesSamAccountName"),
+                entry(MemberResponseWrapper.EMAIL, "mail"));
+    }
+
+    @Test
+    void asMapIsImmutable() {
+        GraphFieldOverrides overrides = new GraphFieldOverrides("a", "b", "c");
+        assertThat(overrides.asMap()).isUnmodifiable();
+    }
+}


### PR DESCRIPTION
### Proposed changes

This pull request introduces a new mechanism for overriding the Microsoft Graph property names used for user synchronization, allowing for more flexible mapping between Polarion user fields and Graph properties. The changes affect both the Java codebase and the documentation, providing new job parameters to specify these overrides and ensuring that they are correctly handled throughout the synchronization process.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
