### PR TITLE
fix: remove extensionAppId and extensionFields from GraphConnector and related classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,8 @@ To run this job on a schedule, configure it in the global `Administration` / `Sc
 <job id="aad_user_synchronization.job" cronExpression="0 0 0 * * ?" name="AAD Synchronization" scope="system">
     <authenticationProviderId>oauth2</authenticationProviderId>
 
-    <!-- Optional: enable directory schema extension expansion (see "Custom extension attributes" below) -->
-    <extensionAppId>abc123de-f456-7890-abcd-ef1234567890</extensionAppId>
-    <extensionFields>id</extensionFields>
-
-    <!-- Optional: override Graph property names when they differ from authentication.xml <mapping> -->
+    <!-- Optional: override Graph property names when they differ from authentication.xml <mapping>
+         (see "Overriding Graph property names per mapping field" below) -->
     <graphIdField>onPremisesSamAccountName</graphIdField>
 
     <groupPrefix>SOME_GROUP_PREFIX_</groupPrefix>
@@ -143,57 +140,6 @@ Example of `authentication.xml`:
 </authentication>
 ```
 
-#### Custom extension attributes
-
-The fields configured in the `<mapping>` block of `authentication.xml` are used by the synchronization
-job as Microsoft Graph property names when fetching user data from `/users/{id}`. For standard properties
-like `displayName`, `mail`, `mailNickname` this works out of the box.
-
-To use an [Azure AD directory schema extension](https://learn.microsoft.com/en-us/graph/extensibility-overview)
-as one of those fields, Microsoft Graph requires the property to be referenced by its fully-qualified name
-`extension_<appIdWithoutDashes>_<name>`. There are two equivalent ways to configure this:
-
-1. **Put the full name into `authentication.xml`** — works without any extra job parameters, but requires
-   the same name on the JWT side too (which usually means setting up an Azure claims mapping policy).
-2. **Keep the bare name in `authentication.xml` and let the job expand it.** Set the following two job
-   parameters and the synchronizer will rewrite the listed mapping fields to
-   `extension_<appIdWithoutDashes>_<name>` before talking to Graph:
-
-   - **`extensionAppId`**: AAD application (client) ID owning the directory schema extension(s). Dashes
-     are stripped automatically when building the Graph property name.
-   - **`extensionFields`**: comma-separated list of mapping fields to expand — any combination of `id`,
-     `name`, `email`. When omitted but `extensionAppId` is set, defaults to `id`.
-
-Values that already start with `extension_` or that contain `/` (nested property paths such as
-`onPremisesExtensionAttributes/extensionAttribute1`) are passed through unchanged, so you can mix
-expanded and verbatim entries freely.
-
-**Example.** With this job configuration:
-
-```xml
-<extensionAppId>abc123de-f456-7890-abcd-ef1234567890</extensionAppId>
-<extensionFields>id,email</extensionFields>
-```
-
-and this `authentication.xml` mapping:
-
-```xml
-<mapping>
-    <id>mycustomid</id>          <!-- bare → extension_abc123def4567890abcdef1234567890_mycustomid -->
-    <name>displayName</name>     <!-- standard property, untouched -->
-    <email>myworkmail</email>    <!-- bare → extension_abc123def4567890abcdef1234567890_myworkmail -->
-</mapping>
-```
-
-the synchronizer will query Graph with `$select=extension_abc123def4567890abcdef1234567890_mycustomid,displayName,extension_abc123def4567890abcdef1234567890_myworkmail`
-when fetching each user, and use the resolved `extension_..._mycustomid` value as the Polarion user identifier.
-
-> [!NOTE]
-> Members of the AAD group are first listed via `/groups/{id}/members` to obtain their AAD object IDs,
-> and then each user is fetched individually via `/users/{aadObjectId}`. The per-user call is required
-> because the `/groups/{id}/members` endpoint returns directory objects that strip extension attributes
-> via `$select`.
-
 #### Overriding Graph property names per mapping field
 
 The `<mapping>` block in `authentication.xml` is shared between Polarion (which uses it at login
@@ -207,9 +153,10 @@ optional job parameters:
 - **`graphEmailField`**: Graph user property to use as the email.
 
 Each override, when set to a non-blank value, replaces the corresponding `<mapping>` entry in the
-Graph `$select` verbatim — no `extension_...` auto-expansion is applied to the overridden value, so
-you can put either a standard built-in property (`onPremisesSamAccountName`, `userPrincipalName`, …)
-or the fully-qualified name of a directory schema extension (`extension_<appIdNoDashes>_<field>`).
+Graph `$select` verbatim. Put in a standard built-in property (`onPremisesSamAccountName`,
+`userPrincipalName`, …) or the fully-qualified name of an
+[Azure AD directory schema extension](https://learn.microsoft.com/en-us/graph/extensibility-overview)
+(`extension_<appIdNoDashes>_<field>`).
 
 **Example — standard Graph property under a different name.** The OAuth2 token exposes a custom
 `sbbuid` claim; in Graph the same logical identifier is stored in the built-in
@@ -231,8 +178,21 @@ or the fully-qualified name of a directory schema extension (`extension_<appIdNo
 
 The synchronizer will query Graph with `$select=onPremisesSamAccountName,displayName,mail` and use
 the `onPremisesSamAccountName` value as the Polarion user identifier. Polarion keeps using the
-`sbbuid` claim at login time because `<mapping>` is unchanged. No directory schema extension is
-needed because `onPremisesSamAccountName` is a standard built-in Graph property.
+`sbbuid` claim at login time because `<mapping>` is unchanged.
+
+**Example — directory schema extension.** The custom user identifier is stored in a Graph schema
+extension owned by an AAD application with id `abc123de-f456-7890-abcd-ef1234567890`:
+
+```xml
+<!-- job configuration: fully-qualified extension property name (app id without dashes) -->
+<graphIdField>extension_abc123def4567890abcdef1234567890_mycustomid</graphIdField>
+```
+
+> [!NOTE]
+> Members of the AAD group are first listed via `/groups/{id}/members` to obtain their AAD object IDs,
+> and then each user is fetched individually via `/users/{aadObjectId}`. The per-user call is required
+> because the `/groups/{id}/members` endpoint returns directory objects that strip extension attributes
+> via `$select`.
 
 #### Group Synchronization
 

--- a/aad-sync-it.properties.example
+++ b/aad-sync-it.properties.example
@@ -14,16 +14,18 @@ clientId=00000000-0000-0000-0000-000000000000
 clientSecret=replace-me
 groupPrefix=TEST_AAD_SYNC_
 
-# AAD application id that owns the directory schema extensions. Empty by default.
-#extensionAppId=00000000-0000-0000-0000-000000000000
-
-# Comma-separated mapping field keys to expand. Empty by default.
-#extensionFields=id,name,email
-
 # Bare attribute names the synchronizer reads from authentication.xml mapping.
 #mappingId=mycustomid
 #mappingName=displayName
 #mappingEmail=mail
+
+# Per-field Microsoft Graph property name overrides. Set these when the Graph property names
+# differ from the authentication.xml mapping (e.g. claim 'sbbuid' vs Graph 'onPremisesSamAccountName'),
+# or to reference a directory schema extension by its fully-qualified name
+# extension_<appIdNoDashes>_<field>.
+#graphIdField=onPremisesSamAccountName
+#graphNameField=displayName
+#graphEmailField=mail
 
 # Optional sanity check — when set, the test asserts this UPN is among the resolved members
 # of the first matching group.

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnit.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnit.java
@@ -10,10 +10,6 @@ public interface AADUserSynchronizationJobUnit extends IJobUnit {
 
     void setAuthenticationProviderId(String authenticationProviderId);
 
-    void setExtensionAppId(String extensionAppId);
-
-    void setExtensionFields(String extensionFields);
-
     void setGraphIdField(String graphIdField);
 
     void setGraphNameField(String graphNameField);

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactory.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactory.java
@@ -14,8 +14,6 @@ import java.util.Map;
 public class AADUserSynchronizationJobUnitFactory implements IJobUnitFactory {
 
     public static final String AUTHENTICATION_PROVIDER_ID = "authenticationProviderId";
-    public static final String EXTENSION_APP_ID = "extensionAppId";
-    public static final String EXTENSION_FIELDS = "extensionFields";
     public static final String GRAPH_ID_FIELD = "graphIdField";
     public static final String GRAPH_NAME_FIELD = "graphNameField";
     public static final String GRAPH_EMAIL_FIELD = "graphEmailField";
@@ -45,18 +43,6 @@ public class AADUserSynchronizationJobUnitFactory implements IJobUnitFactory {
                 AUTHENTICATION_PROVIDER_ID,
                 "Authentication Provider ID",
                 stringType));
-
-        desc.addParameter(new SimpleJobParameter(
-                desc.getRootParameterGroup(),
-                EXTENSION_APP_ID,
-                "AAD application (client) ID owning the directory schema extension(s) referenced from authentication.xml. When set together with extensionFields, the listed mapping fields are automatically expanded to extension_<appIdWithoutDashes>_<name> when querying Microsoft Graph.",
-                stringType).setRequired(false));
-
-        desc.addParameter(new SimpleJobParameter(
-                desc.getRootParameterGroup(),
-                EXTENSION_FIELDS,
-                "Comma-separated list of authentication.xml mapping fields to treat as directory schema extensions: any combination of 'id', 'name', 'email'. Each listed field is auto-expanded with extensionAppId. Defaults to 'id' when only extensionAppId is set.",
-                stringType).setRequired(false));
 
         desc.addParameter(new SimpleJobParameter(
                 desc.getRootParameterGroup(),

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnit.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnit.java
@@ -38,8 +38,6 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
     private final IGraphConnector externalGraphConnector;
 
     private String authenticationProviderId;
-    private String extensionAppId;
-    private String extensionFields;
     private String graphIdField;
     private String graphNameField;
     private String graphEmailField;
@@ -82,7 +80,7 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
         }
 
         String graphApiToken = new OAuth2Client().getToken(authenticationProviderConfiguration);
-        try (GraphConnector ownGraphConnector = new GraphConnector(authenticationProviderConfiguration, graphApiToken, extensionAppId, extensionFields, buildGraphFieldOverrides())) {
+        try (GraphConnector ownGraphConnector = new GraphConnector(authenticationProviderConfiguration, graphApiToken, buildGraphFieldOverrides())) {
             return runWithGraphConnector(ownGraphConnector);
         }
     }
@@ -193,16 +191,6 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
     @Override
     public void setAuthenticationProviderId(String authenticationProviderId) {
         this.authenticationProviderId = authenticationProviderId;
-    }
-
-    @Override
-    public void setExtensionAppId(String extensionAppId) {
-        this.extensionAppId = extensionAppId;
-    }
-
-    @Override
-    public void setExtensionFields(String extensionFields) {
-        this.extensionFields = extensionFields;
     }
 
     @Override

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
@@ -27,11 +27,9 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public class GraphConnector implements IGraphConnector, AutoCloseable {
 
@@ -58,8 +56,6 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
     private final IOAuth2SecurityConfiguration authenticationProviderConfiguration;
     private final String token;
     private final String graphUrl;
-    private final String extensionAppId;
-    private final Set<String> extensionFields;
     private final Map<String, String> graphFieldOverrides;
     private final UrlBuilder urlBuilder;
     private final ObjectMapper objectMapper = prepareObjectMapper();
@@ -71,23 +67,19 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
     private final Client httpClient;
 
     public GraphConnector(IOAuth2SecurityConfiguration authenticationProviderConfiguration, String token) {
-        this(authenticationProviderConfiguration, token, null, null, null, GRAPH_MICROSOFT_URL);
+        this(authenticationProviderConfiguration, token, null, GRAPH_MICROSOFT_URL);
     }
 
     public GraphConnector(IOAuth2SecurityConfiguration authenticationProviderConfiguration, String token,
-                          String extensionAppId, String extensionFields,
                           GraphFieldOverrides graphFieldOverrides) {
-        this(authenticationProviderConfiguration, token, extensionAppId, extensionFields, graphFieldOverrides, GRAPH_MICROSOFT_URL);
+        this(authenticationProviderConfiguration, token, graphFieldOverrides, GRAPH_MICROSOFT_URL);
     }
 
     @VisibleForTesting
     GraphConnector(IOAuth2SecurityConfiguration authenticationProviderConfiguration, String token,
-                   String extensionAppId, String extensionFields,
                    GraphFieldOverrides graphFieldOverrides, String graphUrl) {
         this.authenticationProviderConfiguration = authenticationProviderConfiguration;
         this.token = token;
-        this.extensionAppId = extensionAppId;
-        this.extensionFields = parseExtensionFields(extensionFields, extensionAppId);
         this.graphFieldOverrides = (graphFieldOverrides != null ? graphFieldOverrides : GraphFieldOverrides.EMPTY).asMap();
         this.urlBuilder = new UrlBuilder();
         this.graphUrl = graphUrl;
@@ -107,24 +99,6 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
         } catch (RuntimeException e) {
             JobLogger.getInstance().log("Failed to close Graph HTTP client: %s", e.getMessage());
         }
-    }
-
-    /**
-     * Parses the comma-separated {@code extensionFields} job parameter into a set of mapping field
-     * keys ({@code id}, {@code name}, {@code email}). When unset but {@code extensionAppId} is
-     * configured, defaults to {@code {id}} for backward compatibility — the original use case being
-     * a custom identifier attribute.
-     */
-    private static Set<String> parseExtensionFields(String csv, String extensionAppId) {
-        if (csv == null || csv.isBlank()) {
-            return (extensionAppId == null || extensionAppId.isBlank())
-                    ? Set.of()
-                    : Set.of(MemberResponseWrapper.ID);
-        }
-        return Arrays.stream(csv.split(","))
-                .map(String::trim)
-                .filter(s -> !s.isEmpty())
-                .collect(Collectors.toUnmodifiableSet());
     }
 
     private ObjectMapper prepareObjectMapper() {
@@ -237,53 +211,12 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
     /**
      * Resolves the Microsoft Graph property name to request for the given mapping field role.
      * When a per-field override was supplied via job parameters, it wins unconditionally and is
-     * passed to Graph verbatim (no {@code extension_...} expansion applied). Otherwise falls back
-     * to the value from {@code authentication.xml} {@code <mapping>}, with the legacy
-     * {@code extensionAppId}/{@code extensionFields} auto-expansion applied for backward
-     * compatibility.
+     * passed to Graph verbatim. Otherwise falls back to the value from
+     * {@code authentication.xml} {@code <mapping>}.
      */
     @VisibleForTesting
     String resolveGraphField(String fieldKey, String mappingValue) {
-        String override = graphFieldOverrides.get(fieldKey);
-        if (override != null) {
-            return override;
-        }
-        return expandIfMarked(fieldKey, mappingValue);
-    }
-
-    /**
-     * Returns the configured value, expanded to a directory schema extension property name when the
-     * given mapping field key (one of {@code id}, {@code name}, {@code email}) is listed in
-     * {@code extensionFields}. When the field is not marked as an extension, the value is used as-is.
-     */
-    @VisibleForTesting
-    String expandIfMarked(String fieldKey, String fieldValue) {
-        if (!extensionFields.contains(fieldKey)) {
-            return fieldValue;
-        }
-        return expandExtensionAttribute(fieldValue);
-    }
-
-    /**
-     * If {@code extensionAppId} is configured, expands a bare custom attribute name into the
-     * fully-qualified Microsoft Graph directory schema extension property name
-     * {@code extension_<appIdWithoutDashes>_<name>}. Leaves the value untouched when:
-     * <ul>
-     *     <li>no {@code extensionAppId} is configured;</li>
-     *     <li>the value already starts with {@code extension_} (already a full extension name);</li>
-     *     <li>the value contains a slash (a nested property path such as
-     *         {@code onPremisesExtensionAttributes/extensionAttribute1}).</li>
-     * </ul>
-     */
-    @VisibleForTesting
-    String expandExtensionAttribute(String fieldName) {
-        if (extensionAppId == null || extensionAppId.isBlank()
-                || fieldName == null
-                || fieldName.startsWith("extension_")
-                || fieldName.contains("/")) {
-            return fieldName;
-        }
-        return "extension_" + extensionAppId.replace("-", "") + "_" + fieldName;
+        return graphFieldOverrides.getOrDefault(fieldKey, mappingValue);
     }
 
     @Override

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnitTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnitTest.java
@@ -1,6 +1,7 @@
 package ch.sbb.polarion.extension.aad.synchronizer;
 
 import ch.sbb.polarion.extension.aad.synchronizer.connector.FakeOAuth2SecurityConfiguration;
+import ch.sbb.polarion.extension.aad.synchronizer.connector.GraphConnector;
 import ch.sbb.polarion.extension.aad.synchronizer.connector.GraphFieldOverrides;
 import ch.sbb.polarion.extension.aad.synchronizer.connector.IGraphConnector;
 import ch.sbb.polarion.extension.aad.synchronizer.exception.NotFoundException;
@@ -8,6 +9,7 @@ import ch.sbb.polarion.extension.aad.synchronizer.model.Group;
 import ch.sbb.polarion.extension.aad.synchronizer.model.Member;
 import ch.sbb.polarion.extension.aad.synchronizer.service.IPolarionServiceFactory;
 import ch.sbb.polarion.extension.aad.synchronizer.service.PolarionService;
+import ch.sbb.polarion.extension.aad.synchronizer.utils.OAuth2Client;
 import ch.sbb.polarion.extension.aad.synchronizer.utils.OSGiUtils;
 import com.polarion.alm.projects.IProjectService;
 import com.polarion.alm.shared.api.transaction.ReadOnlyTransaction;
@@ -26,6 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -101,6 +104,57 @@ class UserSynchronizationJobUnitTest {
             verify(polarionService).checkDuplicatedPolarionUsers();
             verify(polarionService).deletePolarionUsers(List.of("testNickName"));
             verify(polarionService).createPolarionUsers(List.of("testNickName"));
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldRunSuccessfullyWithOwnGraphConnectorWhenExternalIsNotProvided() {
+        // Exercises the ownGraphConnector branch of runInternal — the path taken in production
+        // when no external IGraphConnector is registered in OSGi. OAuth2Client.getToken is
+        // intercepted so no real HTTPS call happens, and GraphConnector construction is replaced
+        // with a Mockito mock so the subsequent Graph calls come from the test.
+        UserSynchronizationJobUnit jobUnit = new UserSynchronizationJobUnit(
+                "testName", jobUnitFactory, authenticationProviderConfiguration,
+                securityService, projectService, null);
+        jobUnit.setAuthenticationProviderId("authenticationProviderId");
+        jobUnit.setGroupPrefix("testPrefix");
+        jobUnit.setGraphIdField("onPremisesSamAccountName");
+        jobUnit.setJob(mock(IJob.class));
+
+        try (MockedStatic<TransactionalExecutor> mockedExecutor = Mockito.mockStatic(TransactionalExecutor.class);
+             MockedStatic<OSGiUtils> mockedOSGiUtils = Mockito.mockStatic(OSGiUtils.class);
+             MockedStatic<AuthenticationManager> mockedAuthenticationManager = Mockito.mockStatic(AuthenticationManager.class, RETURNS_DEEP_STUBS);
+             MockedConstruction<OAuth2Client> oauth2Mock = Mockito.mockConstruction(OAuth2Client.class, (mock, ctx) ->
+                     when(mock.getToken(any(IOAuth2SecurityConfiguration.class))).thenReturn("fake-token"));
+             MockedConstruction<GraphConnector> graphMock = Mockito.mockConstruction(GraphConnector.class, (mock, ctx) -> {
+                 when(mock.getGroups("testPrefix")).thenReturn(List.of(new Group("ownGroupId")));
+                 when(mock.getMembers("ownGroupId")).thenReturn(List.of(new Member("ownNick", "ownDisplay", "own@example.com")));
+             })
+        ) {
+            mockedExecutor.when(() -> TransactionalExecutor.executeSafelyInReadOnlyTransaction(any(RunnableInReadOnlyTransaction.class)))
+                    .thenAnswer(invocation -> {
+                        RunnableInReadOnlyTransaction<?> transaction = invocation.getArgument(0);
+                        return transaction.run(mock(ReadOnlyTransaction.class));
+                    });
+            mockedExecutor.when(() -> TransactionalExecutor.executeInWriteTransaction(any(RunnableInWriteTransaction.class)))
+                    .thenAnswer(invocation -> {
+                        RunnableInWriteTransaction<?> transaction = invocation.getArgument(0);
+                        return transaction.run(mock(WriteTransaction.class));
+                    });
+            mockedOSGiUtils.when(() -> OSGiUtils.lookupOSGiService(IPolarionServiceFactory.class))
+                    .thenReturn((IPolarionServiceFactory) (sec, prj, dry, ids) -> polarionService);
+            mockedAuthenticationManager.when(() -> AuthenticationManager.getInstance().authenticators())
+                    .thenReturn(List.of(authenticationProviderConfiguration));
+
+            IJobStatus jobStatus = jobUnit.runInternal(monitor);
+
+            assertThat(jobStatus).isNotNull();
+            assertThat(jobStatus.getType().getName()).isEqualTo("OK");
+            // The ownGraphConnector branch must have actually constructed a GraphConnector —
+            // otherwise the try-with-resources line would never execute in any test.
+            assertThat(graphMock.constructed()).hasSize(1);
+            verify(polarionService).createPolarionUsers(List.of("ownNick"));
         }
     }
 

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
@@ -58,11 +58,12 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
  * clientSecret=...
  * groupPrefix=TEST_AAD_SYNC_
  * # Optional overrides — defaults are vanilla MS Graph user properties
- * # extensionAppId=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
- * # extensionFields=id,name,email
  * # mappingId=mycustomid
  * # mappingName=displayName
  * # mappingEmail=mail
+ * # graphIdField=onPremisesSamAccountName
+ * # graphNameField=displayName
+ * # graphEmailField=mail
  * # expectedUpn=user@example.com
  * }</pre>
  *
@@ -82,18 +83,17 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
  *     <li>{@code clientId} ↔ {@code AAD_SYNC_IT_CLIENT_ID} — required</li>
  *     <li>{@code clientSecret} ↔ {@code AAD_SYNC_IT_CLIENT_SECRET} — required</li>
  *     <li>{@code groupPrefix} ↔ {@code AAD_SYNC_IT_GROUP_PREFIX} — required</li>
- *     <li>{@code extensionAppId} ↔ {@code AAD_SYNC_IT_EXTENSION_APP_ID} — AAD application id
- *         that owns the directory schema extensions. Empty by default. Set this together with
- *         {@code extensionFields} when your test users carry custom extension attributes that
- *         need to be expanded to {@code extension_<appIdNoDashes>_<name>}.</li>
- *     <li>{@code extensionFields} ↔ {@code AAD_SYNC_IT_EXTENSION_FIELDS} — comma-separated
- *         mapping field keys to expand. Empty by default — i.e. mapping fields are passed to
- *         Graph as-is.</li>
  *     <li>{@code mappingId} / {@code mappingName} / {@code mappingEmail} ↔
  *         {@code AAD_SYNC_IT_MAPPING_ID} / {@code _NAME} / {@code _EMAIL} — bare attribute names
  *         the synchronizer reads from {@code authentication.xml}. Default to the standard MS
  *         Graph user properties {@code mailNickname} / {@code displayName} / {@code mail}, so
  *         the IT works against any vanilla Entra group out of the box.</li>
+ *     <li>{@code graphIdField} / {@code graphNameField} / {@code graphEmailField} ↔
+ *         {@code AAD_SYNC_IT_GRAPH_ID_FIELD} / {@code _NAME_FIELD} / {@code _EMAIL_FIELD} — per-field
+ *         Microsoft Graph property name overrides. Empty by default. Set these when the Graph
+ *         property names differ from the authentication.xml mapping (e.g. claim 'sbbuid' vs Graph
+ *         {@code onPremisesSamAccountName}), or to reference a directory schema extension by its
+ *         fully-qualified name {@code extension_<appIdNoDashes>_<field>}.</li>
  *     <li>{@code expectedUpn} ↔ {@code AAD_SYNC_IT_EXPECTED_UPN} — when set, an additional
  *         assertion verifies that this user is among the resolved members of the first matching
  *         group.</li>
@@ -122,8 +122,7 @@ class GraphConnectorIT {
     private GraphConnector connector;
     private String token;
     private String groupPrefix;
-    private String extensionAppId;
-    private String extensionFields;
+    private GraphFieldOverrides overrides;
     private FakeOAuth2SecurityConfiguration config;
 
     @BeforeEach
@@ -133,25 +132,28 @@ class GraphConnectorIT {
         String clientSecret = required("AAD_SYNC_IT_CLIENT_SECRET", "clientSecret");
         groupPrefix = required("AAD_SYNC_IT_GROUP_PREFIX", "groupPrefix");
 
-        extensionAppId = lookup("AAD_SYNC_IT_EXTENSION_APP_ID", "extensionAppId", null);
-        extensionFields = lookup("AAD_SYNC_IT_EXTENSION_FIELDS", "extensionFields", null);
         String mappingId = lookup("AAD_SYNC_IT_MAPPING_ID", "mappingId", "mailNickname");
         String mappingName = lookup("AAD_SYNC_IT_MAPPING_NAME", "mappingName", "displayName");
         String mappingEmail = lookup("AAD_SYNC_IT_MAPPING_EMAIL", "mappingEmail", "mail");
+        String graphIdField = lookup("AAD_SYNC_IT_GRAPH_ID_FIELD", "graphIdField", null);
+        String graphNameField = lookup("AAD_SYNC_IT_GRAPH_NAME_FIELD", "graphNameField", null);
+        String graphEmailField = lookup("AAD_SYNC_IT_GRAPH_EMAIL_FIELD", "graphEmailField", null);
 
         log("--- IT setup ---");
         log("  tenantId        = " + tenantId);
         log("  clientId        = " + clientId);
         log("  clientSecret    = " + maskSecret(clientSecret));
         log("  groupPrefix     = " + groupPrefix);
-        log("  extensionAppId  = " + (extensionAppId == null ? "(empty)" : extensionAppId));
-        log("  extensionFields = " + (extensionFields == null ? "(empty)" : extensionFields));
         log("  mapping.id      = " + mappingId);
         log("  mapping.name    = " + mappingName);
         log("  mapping.email   = " + mappingEmail);
+        log("  graphIdField    = " + (graphIdField == null ? "(empty)" : graphIdField));
+        log("  graphNameField  = " + (graphNameField == null ? "(empty)" : graphNameField));
+        log("  graphEmailField = " + (graphEmailField == null ? "(empty)" : graphEmailField));
         log("  config file     = " + resolvedConfigPath() + (FILE_PROPS.isEmpty() ? " (not loaded)" : " (loaded)"));
 
         config = new FakeOAuth2SecurityConfiguration(mappingId, mappingName, mappingEmail);
+        overrides = new GraphFieldOverrides(graphIdField, graphNameField, graphEmailField);
 
         // Use the real OAuth2Client code path that the production job uses, just constructed via
         // the @VisibleForTesting constructor so we can skip the Polarion UserAccountVault.
@@ -159,7 +161,7 @@ class GraphConnectorIT {
         token = oauth2Client.getToken(String.format(TOKEN_URL_TEMPLATE, tenantId), clientId, clientSecret, SCOPE);
         log("  token acquired  = " + maskSecret(token) + " (length=" + token.length() + ")");
 
-        connector = new GraphConnector(config, token, extensionAppId, extensionFields, null);
+        connector = new GraphConnector(config, token, overrides);
     }
 
     @AfterEach
@@ -274,7 +276,7 @@ class GraphConnectorIT {
      */
     @Test
     void connectorCloseIsIdempotent() {
-        GraphConnector throwaway = new GraphConnector(config, token, extensionAppId, extensionFields, null);
+        GraphConnector throwaway = new GraphConnector(config, token, overrides);
         throwaway.close();
         assertThatNoException()
                 .as("a second close() on an already-closed connector must not throw")

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
@@ -76,7 +76,7 @@ class GraphConnectorTest {
     }
 
     private GraphConnector createConnector(WireMockRuntimeInfo wmRuntimeInfo) {
-        return register(new GraphConnector(authenticationProviderConfiguration, "test", null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
+        return register(new GraphConnector(authenticationProviderConfiguration, "test", null, wmRuntimeInfo.getHttpBaseUrl()));
     }
 
     private static Stream<Arguments> testMemberValues() {
@@ -158,7 +158,7 @@ class GraphConnectorTest {
                 + "\"mail\":\"some.user@example.com\"}";
         mockGetUserCallWithBody(aadObjectId, userBody, 200);
 
-        GraphConnector connector = register(new GraphConnector(config, "test", null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
+        GraphConnector connector = register(new GraphConnector(config, "test", null, wmRuntimeInfo.getHttpBaseUrl()));
         List<Member> members = connector.getMembers(groupKey);
 
         assertThat(members).hasSize(1);
@@ -185,85 +185,11 @@ class GraphConnectorTest {
                 + "\"mail\":\"nested.user@example.com\"}";
         mockGetUserCallWithBody(aadObjectId, userBody, 200);
 
-        GraphConnector connector = register(new GraphConnector(config, "test", null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
+        GraphConnector connector = register(new GraphConnector(config, "test", null, wmRuntimeInfo.getHttpBaseUrl()));
         List<Member> members = connector.getMembers(groupKey);
 
         assertThat(members).hasSize(1);
         assertThat(members.get(0).getId()).isEqualTo(expectedValue);
-    }
-
-    @Test
-    void getMembersExpandsBareAttributeUsingExtensionAppId(WireMockRuntimeInfo wmRuntimeInfo) {
-        String groupKey = "myGroup";
-        String aadObjectId = "cccccccc-cccc-cccc-cccc-cccccccccccc";
-        // The user puts only the bare claim name in authentication.xml...
-        String bareAttribute = "mycustomid";
-        // ...and the AAD application id (with dashes) in the extensionAppId job parameter.
-        String appId = "abc123de-f456-7890-abcd-ef1234567890";
-        String appIdNoDashes = "abc123def4567890abcdef1234567890";
-        String expandedAttribute = "extension_" + appIdNoDashes + "_" + bareAttribute;
-        String customValue = "9876";
-
-        FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration(bareAttribute, "displayName", "mail");
-
-        String groupBody = "{\"value\":[{\"@odata.type\":\"#microsoft.graph.user\",\"id\":\"" + aadObjectId + "\"}]}";
-        mockGetMemberCallWithBody(groupKey, groupBody, 200);
-
-        // The /users/{id} response uses the fully-qualified Graph property name
-        String userBody = "{\"@odata.type\":\"#microsoft.graph.user\","
-                + "\"" + expandedAttribute + "\":\"" + customValue + "\","
-                + "\"displayName\":\"Bare User\","
-                + "\"mail\":\"bare.user@example.com\"}";
-        mockGetUserCallWithBody(aadObjectId, userBody, 200);
-
-        // extensionFields not set → defaults to "id" so the bare attribute gets expanded
-        GraphConnector connector = register(new GraphConnector(config, "test", appId, null, null, wmRuntimeInfo.getHttpBaseUrl()));
-        List<Member> members = connector.getMembers(groupKey);
-
-        assertThat(members).hasSize(1);
-        assertThat(members.get(0).getId()).isEqualTo(customValue);
-        // The Graph $select query should also have used the expanded attribute name
-        com.github.tomakehurst.wiremock.client.WireMock.verify(
-                com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor(urlPathEqualTo("/v1.0/users/" + aadObjectId))
-                        .withQueryParam("$select", com.github.tomakehurst.wiremock.client.WireMock.containing(expandedAttribute)));
-    }
-
-    @Test
-    void getMembersExpandsMultipleFieldsViaExtensionFields(WireMockRuntimeInfo wmRuntimeInfo) {
-        String groupKey = "myGroup";
-        String aadObjectId = "dddddddd-dddd-dddd-dddd-dddddddddddd";
-        String appId = "abc-123";
-        String appIdNoDashes = "abc123";
-        // id and email are custom extensions; name stays standard
-        String bareId = "mycustomid";
-        String bareEmail = "myworkmail";
-        String expandedId = "extension_" + appIdNoDashes + "_" + bareId;
-        String expandedEmail = "extension_" + appIdNoDashes + "_" + bareEmail;
-
-        FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration(bareId, "displayName", bareEmail);
-
-        String groupBody = "{\"value\":[{\"@odata.type\":\"#microsoft.graph.user\",\"id\":\"" + aadObjectId + "\"}]}";
-        mockGetMemberCallWithBody(groupKey, groupBody, 200);
-
-        String userBody = "{\"@odata.type\":\"#microsoft.graph.user\","
-                + "\"" + expandedId + "\":\"the-id\","
-                + "\"displayName\":\"Multi User\","
-                + "\"" + expandedEmail + "\":\"work@example.com\"}";
-        mockGetUserCallWithBody(aadObjectId, userBody, 200);
-
-        GraphConnector connector = register(new GraphConnector(config, "test", appId, "id, email", null, wmRuntimeInfo.getHttpBaseUrl()));
-        List<Member> members = connector.getMembers(groupKey);
-
-        assertThat(members).hasSize(1);
-        assertThat(members.get(0).getId()).isEqualTo("the-id");
-        assertThat(members.get(0).getName()).isEqualTo("Multi User");
-        assertThat(members.get(0).getEmail()).isEqualTo("work@example.com");
-        // Both expanded names must be present in the $select query, displayName must remain standard
-        com.github.tomakehurst.wiremock.client.WireMock.verify(
-                com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor(urlPathEqualTo("/v1.0/users/" + aadObjectId))
-                        .withQueryParam("$select", com.github.tomakehurst.wiremock.client.WireMock.containing(expandedId))
-                        .withQueryParam("$select", com.github.tomakehurst.wiremock.client.WireMock.containing("displayName"))
-                        .withQueryParam("$select", com.github.tomakehurst.wiremock.client.WireMock.containing(expandedEmail)));
     }
 
     @Test
@@ -292,7 +218,7 @@ class GraphConnectorTest {
         mockGetUserCallWithBody(aadObjectId, userBody, 200);
 
         GraphConnector connector = register(new GraphConnector(
-                config, "test", null, null, new GraphFieldOverrides(graphPropertyName, null, null), wmRuntimeInfo.getHttpBaseUrl()));
+                config, "test", new GraphFieldOverrides(graphPropertyName, null, null), wmRuntimeInfo.getHttpBaseUrl()));
         List<Member> members = connector.getMembers(groupKey);
 
         assertThat(members).hasSize(1);
@@ -309,30 +235,30 @@ class GraphConnectorTest {
     }
 
     @Test
-    void resolveGraphFieldPrefersOverrideOverMappingAndSkipsExtensionExpansion() {
-        // The override must win even when extensionAppId/extensionFields would otherwise auto-expand
-        // the value from <mapping>. Writing the extension-prefixed name (or any other Graph property
-        // name) into graphIdField replaces the mapping value verbatim — no second pass of expansion.
+    void resolveGraphFieldPrefersOverrideOverMapping() {
+        // Confirms that when graphIdField / graphNameField / graphEmailField are set via job
+        // parameters they replace the authentication.xml <mapping> value verbatim. Blank overrides
+        // are treated as unset, and each field is resolved independently.
         FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration("sbbuid", "displayName", "mail");
 
-        // No overrides → falls back to mapping + extension expansion
+        // No overrides → falls back to the mapping value as-is
         GraphConnector noOverrides = register(new GraphConnector(
-                config, "test", "abc-123", "id", null, "http://localhost"));
-        assertThat(noOverrides.resolveGraphField("id", "sbbuid")).isEqualTo("extension_abc123_sbbuid");
+                config, "test", null, "http://localhost"));
+        assertThat(noOverrides.resolveGraphField("id", "sbbuid")).isEqualTo("sbbuid");
 
-        // With override → override wins, no expansion applied even though "id" is in extensionFields
+        // Override wins and is passed to Graph verbatim
         GraphConnector withOverride = register(new GraphConnector(
-                config, "test", "abc-123", "id", new GraphFieldOverrides("onPremisesSamAccountName", null, null), "http://localhost"));
+                config, "test", new GraphFieldOverrides("onPremisesSamAccountName", null, null), "http://localhost"));
         assertThat(withOverride.resolveGraphField("id", "sbbuid")).isEqualTo("onPremisesSamAccountName");
 
         // Blank override is treated as unset
         GraphConnector blankOverride = register(new GraphConnector(
-                config, "test", null, null, new GraphFieldOverrides("   ", null, null), "http://localhost"));
+                config, "test", new GraphFieldOverrides("   ", null, null), "http://localhost"));
         assertThat(blankOverride.resolveGraphField("id", "sbbuid")).isEqualTo("sbbuid");
 
         // Per-field independence: only the field with an override is replaced
         GraphConnector partial = register(new GraphConnector(
-                config, "test", null, null, new GraphFieldOverrides("onPremisesSamAccountName", null, null), "http://localhost"));
+                config, "test", new GraphFieldOverrides("onPremisesSamAccountName", null, null), "http://localhost"));
         assertThat(partial.resolveGraphField("id", "sbbuid")).isEqualTo("onPremisesSamAccountName");
         assertThat(partial.resolveGraphField("name", "displayName")).isEqualTo("displayName");
         assertThat(partial.resolveGraphField("email", "mail")).isEqualTo("mail");
@@ -349,46 +275,8 @@ class GraphConnectorTest {
         assertThat(minimal).isNotNull();
 
         GraphConnector withOverrides = register(new GraphConnector(
-                config, "tok", null, null, new GraphFieldOverrides("onPremisesSamAccountName", null, null)));
+                config, "tok", new GraphFieldOverrides("onPremisesSamAccountName", null, null)));
         assertThat(withOverrides).isNotNull();
-    }
-
-    @Test
-    void expandExtensionAttributeBehaviour() {
-        FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration();
-        // No extensionAppId → bare name passes through unchanged
-        GraphConnector noAppIdConnector = register(new GraphConnector(config, "test", null, null, null, "http://localhost"));
-        assertThat(noAppIdConnector.expandExtensionAttribute("mycustomid")).isEqualTo("mycustomid");
-
-        // With extensionAppId → bare name gets expanded, dashes stripped from appId
-        GraphConnector withAppIdConnector = register(new GraphConnector(config, "test", "abc-123-def", null, null, "http://localhost"));
-        assertThat(withAppIdConnector.expandExtensionAttribute("mycustomid")).isEqualTo("extension_abc123def_mycustomid");
-        // Already-qualified name is not double-prefixed
-        assertThat(withAppIdConnector.expandExtensionAttribute("extension_xxx_yyy")).isEqualTo("extension_xxx_yyy");
-        // Nested path is left untouched
-        assertThat(withAppIdConnector.expandExtensionAttribute("onPremisesExtensionAttributes/extensionAttribute1"))
-                .isEqualTo("onPremisesExtensionAttributes/extensionAttribute1");
-    }
-
-    @Test
-    void expandIfMarkedRespectsExtensionFields() {
-        FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration();
-
-        // Default behaviour when no explicit extensionFields list is given but an extensionAppId is
-        // configured: only the id mapping role is auto-expanded.
-        GraphConnector defaultConnector = register(new GraphConnector(config, "test", "abc-123", null, null, "http://localhost"));
-        assertThat(defaultConnector.expandIfMarked("id", "mycustomid")).isEqualTo("extension_abc123_mycustomid");
-        assertThat(defaultConnector.expandIfMarked("email", "mail")).isEqualTo("mail");
-
-        // Explicit list of fields
-        GraphConnector multiConnector = register(new GraphConnector(config, "test", "abc-123", "id,email", null, "http://localhost"));
-        assertThat(multiConnector.expandIfMarked("id", "mycustomid")).isEqualTo("extension_abc123_mycustomid");
-        assertThat(multiConnector.expandIfMarked("name", "displayName")).isEqualTo("displayName");
-        assertThat(multiConnector.expandIfMarked("email", "myworkmail")).isEqualTo("extension_abc123_myworkmail");
-
-        // No appId, no fields → nothing happens
-        GraphConnector noopConnector = register(new GraphConnector(config, "test", null, null, null, "http://localhost"));
-        assertThat(noopConnector.expandIfMarked("id", "mycustomid")).isEqualTo("mycustomid");
     }
 
     @Test
@@ -569,13 +457,17 @@ class GraphConnectorTest {
         // properties at the top level. No 'value' wrapper.
         String groupKey = "myGroup";
         String aadObjectId = "11111111-1111-1111-1111-111111111111";
-        // The bare names that appear in authentication.xml — same as the customer scenario.
+        // The bare names that appear in authentication.xml — used by Polarion at login time
+        // to read claims from the OAuth2 token.
         String mappingId = "mycustomid";
         String mappingName = "name";
         String mappingEmail = "email";
-        // The extension owner app id (with dashes) configured as extensionAppId job parameter.
-        // Stripping dashes yields aaaaaaaabbbbccccddddeeeeeeeeeeee, which the fixture uses.
-        String extensionAppId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        // The fully-qualified Graph property names that the job parameters point at. Schema
+        // extensions are referenced in Graph as extension_<appIdNoDashes>_<field>; the fixture
+        // uses aaaaaaaabbbbccccddddeeeeeeeeeeee as the owning app id.
+        String graphId = "extension_aaaaaaaabbbbccccddddeeeeeeeeeeee_mycustomid";
+        String graphName = "extension_aaaaaaaabbbbccccddddeeeeeeeeeeee_name";
+        String graphEmail = "extension_aaaaaaaabbbbccccddddeeeeeeeeeeee_email";
 
         FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration(mappingId, mappingName, mappingEmail);
 
@@ -585,7 +477,8 @@ class GraphConnectorTest {
         // /users/{id} returns the realistic Graph response loaded from the fixture.
         mockGetUserCallWithBody(aadObjectId, getContent("userWithExtensionAttributes.json"), 200);
 
-        GraphConnector connector = register(new GraphConnector(config, "test", extensionAppId, "id,name,email", null, wmRuntimeInfo.getHttpBaseUrl()));
+        GraphConnector connector = register(new GraphConnector(config, "test",
+                new GraphFieldOverrides(graphId, graphName, graphEmail), wmRuntimeInfo.getHttpBaseUrl()));
         List<Member> members = connector.getMembers(groupKey);
 
         assertThat(members).hasSize(1);
@@ -594,21 +487,18 @@ class GraphConnectorTest {
         assertThat(member.getName()).isEqualTo("John Doe");
         assertThat(member.getEmail()).isEqualTo("john.doe@example.com");
 
-        // The Graph $select must reference the fully-expanded extension property names — that's
+        // The Graph $select must reference the fully-qualified extension property names — that's
         // exactly what makes the difference between issue #74 and a working request.
-        String expandedId = "extension_aaaaaaaabbbbccccddddeeeeeeeeeeee_mycustomid";
-        String expandedName = "extension_aaaaaaaabbbbccccddddeeeeeeeeeeee_name";
-        String expandedEmail = "extension_aaaaaaaabbbbccccddddeeeeeeeeeeee_email";
         verify(getRequestedFor(urlPathEqualTo("/v1.0/users/" + aadObjectId))
-                .withQueryParam("$select", com.github.tomakehurst.wiremock.client.WireMock.containing(expandedId))
-                .withQueryParam("$select", com.github.tomakehurst.wiremock.client.WireMock.containing(expandedName))
-                .withQueryParam("$select", com.github.tomakehurst.wiremock.client.WireMock.containing(expandedEmail)));
+                .withQueryParam("$select", com.github.tomakehurst.wiremock.client.WireMock.containing(graphId))
+                .withQueryParam("$select", com.github.tomakehurst.wiremock.client.WireMock.containing(graphName))
+                .withQueryParam("$select", com.github.tomakehurst.wiremock.client.WireMock.containing(graphEmail)));
     }
 
     @Test
     void getMembersParsesRealisticUserResponseWithVanillaAttributes(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
-        // Vanilla MS Graph properties: mailNickname/displayName/mail. No extensionAppId, no
-        // extensionFields — bare names go straight into $select. Validates the simplest possible
+        // Vanilla MS Graph properties: mailNickname/displayName/mail. No graphIdField overrides —
+        // the <mapping> names go straight into $select. Validates the simplest possible
         // synchronizer configuration end-to-end through the parser.
         String groupKey = "myGroup";
         String aadObjectId = "11111111-1111-1111-1111-111111111111";
@@ -620,7 +510,7 @@ class GraphConnectorTest {
         mockGetMemberCallWithBody(groupKey, groupBody, 200);
         mockGetUserCallWithBody(aadObjectId, getContent("userWithVanillaAttributes.json"), 200);
 
-        GraphConnector connector = register(new GraphConnector(config, "test", null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
+        GraphConnector connector = register(new GraphConnector(config, "test", null, wmRuntimeInfo.getHttpBaseUrl()));
         List<Member> members = connector.getMembers(groupKey);
 
         assertThat(members).hasSize(1);
@@ -639,7 +529,9 @@ class GraphConnectorTest {
         // still come through normally.
         String groupKey = "myGroup";
         String aadObjectId = "11111111-1111-1111-1111-111111111111";
-        String extensionAppId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        String graphId = "extension_aaaaaaaabbbbccccddddeeeeeeeeeeee_mycustomid";
+        String graphName = "extension_aaaaaaaabbbbccccddddeeeeeeeeeeee_name";
+        String graphEmail = "extension_aaaaaaaabbbbccccddddeeeeeeeeeeee_email";
 
         FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration("mycustomid", "name", "email");
 
@@ -647,7 +539,8 @@ class GraphConnectorTest {
         mockGetMemberCallWithBody(groupKey, groupBody, 200);
         mockGetUserCallWithBody(aadObjectId, getContent("userWithMissingExtensionValue.json"), 200);
 
-        GraphConnector connector = register(new GraphConnector(config, "test", extensionAppId, "id,name,email", null, wmRuntimeInfo.getHttpBaseUrl()));
+        GraphConnector connector = register(new GraphConnector(config, "test",
+                new GraphFieldOverrides(graphId, graphName, graphEmail), wmRuntimeInfo.getHttpBaseUrl()));
         List<Member> members = connector.getMembers(groupKey);
 
         assertThat(members).hasSize(1);
@@ -664,20 +557,20 @@ class GraphConnectorTest {
         // containing only @odata.context — no id, no @odata.type, none of the requested fields.
         // The parser must not crash. All Member fields end up null. GraphService.getAadMemberIds
         // would silently drop this user via its non-null id filter, which is the silent failure
-        // mode this test pins down — anyone breaking the extension expansion logic will see this
+        // mode this test pins down — anyone breaking the field resolution logic will see this
         // test fail with a clear pointer to the regression.
         String groupKey = "myGroup";
         String aadObjectId = "11111111-1111-1111-1111-111111111111";
 
-        // Customer-style mapping but WITHOUT extensionAppId — so expandIfMarked returns the bare
-        // names unchanged, and Graph silently drops them.
+        // Customer-style mapping with bare extension names that Graph does not understand as-is
+        // (no graphIdField override applied), so Graph silently drops them from the response.
         FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration("mycustomid", "name", "email");
 
         String groupBody = "{\"value\":[{\"@odata.type\":\"#microsoft.graph.user\",\"id\":\"" + aadObjectId + "\"}]}";
         mockGetMemberCallWithBody(groupKey, groupBody, 200);
         mockGetUserCallWithBody(aadObjectId, getContent("userMinimalEntity.json"), 200);
 
-        GraphConnector connector = register(new GraphConnector(config, "test", null, null, null, wmRuntimeInfo.getHttpBaseUrl()));
+        GraphConnector connector = register(new GraphConnector(config, "test", null, wmRuntimeInfo.getHttpBaseUrl()));
         List<Member> members = connector.getMembers(groupKey);
 
         assertThat(members).hasSize(1);


### PR DESCRIPTION
### Proposed changes

This pull request removes support for the legacy mechanism of auto-expanding Azure AD directory schema extension attributes using the `extensionAppId` and `extensionFields` job parameters. Instead, it now requires explicit per-field Microsoft Graph property name overrides (e.g., using the fully-qualified extension property name) for referencing custom attributes. The documentation, configuration files, Java interfaces, and implementation have been updated to reflect this change, simplifying the configuration and codebase.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
