### PR TITLE
feat: add request count tracking and optimize member fetching logic in GraphConnector

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnit.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnit.java
@@ -142,6 +142,13 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
         );
         JobLogger.getInstance().separator();
 
+        int requestCount = graphConnector.getRequestCount();
+        if (requestCount > 0) {
+            JobLogger.getInstance().separator();
+            JobLogger.getInstance().log("Total Microsoft Graph requests made during this run: %d", requestCount);
+            JobLogger.getInstance().separator();
+        }
+
         return getStatusOK(JobLogger.getInstance().getLog());
     }
 

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
@@ -60,6 +60,13 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
     private final UrlBuilder urlBuilder;
     private final ObjectMapper objectMapper = prepareObjectMapper();
     /**
+     * Monotonically-incremented counter of logical Microsoft Graph operations (one increment per
+     * {@link #fetchMSGraphApi} call, regardless of retry attempts). Exposed via
+     * {@link #getRequestCount()} for integration tests that need to verify batch-vs-per-user
+     * call patterns.
+     */
+    private int requestCount;
+    /**
      * One JAX-RS {@link Client} per connector instance, reused for every Graph request. Avoids the
      * per-call TLS handshake that dominated latency on groups with hundreds of members. The
      * underlying connection pool is released by {@link #close()} at the end of the job.
@@ -84,6 +91,11 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
         this.urlBuilder = new UrlBuilder();
         this.graphUrl = graphUrl;
         this.httpClient = ClientBuilder.newClient();
+    }
+
+    @Override
+    public int getRequestCount() {
+        return requestCount;
     }
 
     /**
@@ -121,24 +133,24 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
     /**
      * Resolves all members of an AAD group through the configured field mapping.
      *
-     * <p><b>Why two requests per member instead of one batch call</b>: the synchronizer used to
-     * read members in a single {@code /groups/{id}/members?$select=...} call, but that endpoint
-     * returns {@code directoryObject}s and {@code $select} silently drops directory schema
-     * extension properties on certain configurations — see issue #74. Switching to a per-user
-     * fetch via {@code /users/{aadObjectId}} guarantees the extension attributes come back
-     * populated and isolates the synchronizer from any future {@code /members} quirks (nested
-     * directory object types, mixed-tenant guests, multi-valued extensions). The cost is an
-     * extra {@code N} HTTPS calls per group: tolerable for the daily cron, mitigated by
-     * connection reuse via the per-connector {@link Client} and by retry/backoff handling on
-     * 429/503/504 in {@link #fetchMSGraphApi}.</p>
+     * <p>For flat standard Graph properties (e.g. {@code employeeId}, {@code displayName},
+     * {@code mail}) a single batch call {@code /groups/{id}/members?$select=...} returns every
+     * member's projected fields inline, giving {@code 1 + ceil(N / pageSize)} HTTPS calls per
+     * group instead of {@code 1 + N}.</p>
+     *
+     * <p>When any resolved field is a directory schema extension (prefix {@code extension_}) or
+     * a nested property path (contains {@code /}), the connector falls back to a per-user fetch
+     * via {@code /users/{aadObjectId}}. Background: issue #74 reported that {@code $select} on
+     * {@code /groups/{id}/members} silently dropped extension attributes on certain tenant
+     * configurations. Per-user fetch is the safe path for that case; the cost is {@code N}
+     * extra HTTPS calls, mitigated by the shared {@link Client} connection pool and by
+     * retry/backoff handling on 429/503/504 in {@link #fetchMSGraphApi}.</p>
      */
     @Override
     public List<Member> getMembers(String key) {
         String idField = resolveGraphField(MemberResponseWrapper.ID, authenticationProviderConfiguration.mapping().id());
         String nameField = resolveGraphField(MemberResponseWrapper.NAME, authenticationProviderConfiguration.mapping().name());
         String emailField = resolveGraphField(MemberResponseWrapper.EMAIL, authenticationProviderConfiguration.mapping().email());
-
-        List<String> aadObjectIds = fetchGroupMemberObjectIds(key);
 
         Map<String, String> userFieldsMapping = Map.ofEntries(
                 Map.entry(MemberResponseWrapper.ID, idField),
@@ -147,11 +159,91 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
         );
         String selectValue = "%s,%s,%s".formatted(idField, nameField, emailField);
 
+        if (requiresPerUserFetch(idField, nameField, emailField)) {
+            return fetchMembersPerUser(key, selectValue, userFieldsMapping);
+        }
+        return fetchMembersBatch(key, selectValue, userFieldsMapping);
+    }
+
+    /**
+     * True when any resolved Graph property name requires the per-user fallback path: directory
+     * schema extensions (prefix {@code extension_}) or nested property paths (contain {@code /}).
+     * See the {@link #getMembers} javadoc for the rationale.
+     */
+    @VisibleForTesting
+    static boolean requiresPerUserFetch(String... fields) {
+        for (String f : fields) {
+            if (f != null && (f.startsWith("extension_") || f.contains("/"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private List<Member> fetchMembersPerUser(String groupKey, String selectValue, Map<String, String> userFieldsMapping) {
+        List<String> aadObjectIds = fetchGroupMemberObjectIds(groupKey);
         List<Member> members = new ArrayList<>(aadObjectIds.size());
         for (String aadObjectId : aadObjectIds) {
             members.add(fetchUser(aadObjectId, selectValue, userFieldsMapping));
         }
         return members;
+    }
+
+    private List<Member> fetchMembersBatch(String groupKey, String selectValue, Map<String, String> userFieldsMapping) {
+        String url = urlBuilder.build(graphUrl, GraphOption.GROUPS, String.format("%s/members", groupKey));
+        List<Member> members = new ArrayList<>();
+        String body = fetchMSGraphApi(url, "$select", selectValue, String.class);
+        String nextLink = collectUserMembers(body, members, userFieldsMapping);
+        while (nextLink != null) {
+            body = fetchMSGraphApi(nextLink, null, null, String.class);
+            nextLink = collectUserMembers(body, members, userFieldsMapping);
+        }
+        return members;
+    }
+
+    /**
+     * Walks one page of a {@code /groups/{id}/members} response, building a {@link Member} for
+     * each {@code @odata.type == #microsoft.graph.user} entry. Non-user directory objects
+     * (nested groups, service principals, devices, organizational contacts) are skipped — the
+     * same filter as {@link #collectUserMemberIds}, applied here against the already-projected
+     * user fields instead of bare ids.
+     *
+     * @return the {@code @odata.nextLink} for cursor-based pagination, or {@code null}.
+     */
+    private String collectUserMembers(String body, List<Member> sink, Map<String, String> fieldsMapping) {
+        try {
+            JsonNode root = objectMapper.readTree(body);
+            JsonNode value = root.get(JsonListParser.VALUE);
+            if (value != null && value.isArray()) {
+                for (JsonNode item : value) {
+                    JsonNode type = item.get("@odata.type");
+                    if (type == null || !GRAPH_USER_TYPE.equals(type.asText())) {
+                        continue;
+                    }
+                    sink.add(parseMember(item, fieldsMapping));
+                }
+            }
+            JsonNode nextLink = root.get(JsonListParser.NEXT_LINK);
+            return (nextLink != null && !nextLink.isNull()) ? nextLink.asText() : null;
+        } catch (JsonProcessingException e) {
+            throw new ResponseParsingException(e);
+        }
+    }
+
+    private static Member parseMember(JsonNode item, Map<String, String> fieldsMapping) {
+        Member m = new Member();
+        m.setId(readTextField(item, fieldsMapping.get(MemberResponseWrapper.ID)));
+        m.setName(readTextField(item, fieldsMapping.get(MemberResponseWrapper.NAME)));
+        m.setEmail(readTextField(item, fieldsMapping.get(MemberResponseWrapper.EMAIL)));
+        return m;
+    }
+
+    private static String readTextField(JsonNode node, String fieldName) {
+        if (fieldName == null) {
+            return null;
+        }
+        JsonNode field = node.get(fieldName);
+        return (field == null || field.isNull()) ? null : field.asText();
     }
 
     private static final String GRAPH_USER_TYPE = "#microsoft.graph.user";
@@ -230,6 +322,7 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
     }
 
     private <T> T fetchMSGraphApi(String url, String queryParamName, String queryParamValue, Class<T> targetClass) {
+        requestCount++;
         WebTarget webTarget = httpClient.target(url);
         if (queryParamName != null && queryParamValue != null) {
             webTarget = webTarget.queryParam(queryParamName, queryParamValue);

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
@@ -37,6 +37,7 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
     private static final String SENT_REQUEST_MESSAGE = "Sent request: %s";
     private static final int JSON_INDENT_FACTOR = 4;
     private static final String GRAPH_MICROSOFT_URL = "https://graph.microsoft.com";
+    private static final String SELECT_QUERY_PARAM = "$select";
 
     /**
      * Maximum number of times a single Microsoft Graph request will be retried after receiving a
@@ -192,7 +193,7 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
     private List<Member> fetchMembersBatch(String groupKey, String selectValue, Map<String, String> userFieldsMapping) {
         String url = urlBuilder.build(graphUrl, GraphOption.GROUPS, String.format("%s/members", groupKey));
         List<Member> members = new ArrayList<>();
-        String body = fetchMSGraphApi(url, "$select", selectValue, String.class);
+        String body = fetchMSGraphApi(url, SELECT_QUERY_PARAM, selectValue, String.class);
         String nextLink = collectUserMembers(body, members, userFieldsMapping);
         while (nextLink != null) {
             body = fetchMSGraphApi(nextLink, null, null, String.class);
@@ -239,9 +240,6 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
     }
 
     private static String readTextField(JsonNode node, String fieldName) {
-        if (fieldName == null) {
-            return null;
-        }
         JsonNode field = node.get(fieldName);
         return (field == null || field.isNull()) ? null : field.asText();
     }
@@ -250,7 +248,7 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
 
     private List<String> fetchGroupMemberObjectIds(String key) {
         String url = urlBuilder.build(graphUrl, GraphOption.GROUPS, String.format("%s/members", key));
-        String body = fetchMSGraphApi(url, "$select", "id", String.class);
+        String body = fetchMSGraphApi(url, SELECT_QUERY_PARAM, "id", String.class);
 
         List<String> ids = new ArrayList<>();
         String nextLink = collectUserMemberIds(body, ids);
@@ -296,7 +294,7 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
 
     private Member fetchUser(String aadObjectId, String selectValue, Map<String, String> fieldsMapping) {
         String url = urlBuilder.build(graphUrl, GraphOption.USERS, aadObjectId);
-        String body = fetchMSGraphApi(url, "$select", selectValue, String.class);
+        String body = fetchMSGraphApi(url, SELECT_QUERY_PARAM, selectValue, String.class);
         return JsonListParser.parseObject(body, fieldsMapping, Member.class);
     }
 

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/IGraphConnector.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/IGraphConnector.java
@@ -14,4 +14,15 @@ public interface IGraphConnector {
     List<Member> getMembers(String key);
 
     OrganizationData getOrganizationData();
+
+    /**
+     * Number of logical Microsoft Graph calls made by this connector so far. Monotonically
+     * non-decreasing over the connector's lifetime. Exposed so the synchronization job can log
+     * the total Graph load per run and so integration tests can verify batch-vs-per-user call
+     * patterns. External {@link IGraphConnector} implementations that don't track requests
+     * should return {@code 0}; the job log treats {@code 0} as "unavailable".
+     */
+    default int getRequestCount() {
+        return 0;
+    }
 }

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnitTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnitTest.java
@@ -93,6 +93,10 @@ class UserSynchronizationJobUnitTest {
             mockedOSGiUtils.when(() -> OSGiUtils.lookupOSGiService(IPolarionServiceFactory.class)).thenReturn((IPolarionServiceFactory) (polarionSecurityService, polarionProjectService, dryRun, memberIds) -> polarionService);
             when(externalGraphConnector.getGroups("testPrefix")).thenReturn(List.of(new Group("testGroupId")));
             when(externalGraphConnector.getMembers("testGroupId")).thenReturn(List.of(new Member("testNickName", "testDisplayName", "testEMail")));
+            // Positive request count exercises the summary log branch in runWithGraphConnector.
+            // The companion own-connector test leaves the count at Mockito's default 0 to cover
+            // the complementary branch.
+            when(externalGraphConnector.getRequestCount()).thenReturn(42);
             mockedAuthenticationManager.when(() -> AuthenticationManager.getInstance().authenticators()).thenReturn(List.of(authenticationProviderConfiguration));
 
             // Act

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
@@ -234,6 +234,73 @@ class GraphConnectorIT {
         }
     }
 
+    /**
+     * Batch path: when all three mapped/overridden Graph property names are flat standard User
+     * properties (the SBB production scenario — sbbuid claim mapped to {@code employeeId} on the
+     * Graph side), {@link GraphConnector#getMembers(String)} must fetch every member with a single
+     * {@code /groups/{id}/members?$select=...} request and must not hit {@code /users/{id}}.
+     */
+    @Test
+    void getMembersUsesSingleBatchRequestForStandardGraphProperties() {
+        List<Group> groups = connector.getGroups(groupPrefix);
+        assertThat(groups).isNotEmpty();
+        Group firstGroup = groups.get(0);
+        log("--- verifying batch path against group " + firstGroup.getId() + " ---");
+
+        int before = connector.getRequestCount();
+        List<Member> members = connector.getMembers(firstGroup.getId());
+        int delta = connector.getRequestCount() - before;
+
+        log("  members resolved = " + members.size());
+        log("  Graph requests   = " + delta);
+
+        assertThat(members)
+                .as("test group must have at least one member for this test to be meaningful")
+                .isNotEmpty();
+        assertThat(delta)
+                .as("batch path must use exactly one Graph request to resolve %d member(s) — an N+1 pattern here means the smart-switch routing is broken",
+                        members.size())
+                .isEqualTo(1);
+    }
+
+    /**
+     * Per-user fallback: when any resolved Graph property name is a directory schema extension
+     * (prefix {@code extension_}), {@link GraphConnector#getMembers(String)} must fall back to
+     * {@code 1 + N} requests (one {@code /groups/{id}/members?$select=id} listing call plus one
+     * {@code /users/{aadObjectId}} call per user). This is the safety net for issue #74.
+     */
+    @Test
+    void getMembersFallsBackToPerUserFetchWhenExtensionOverrideIsSet() {
+        String extensionId = "extension_30a1540993ca483783cf4011c4ba938a_sbbuid";
+        GraphFieldOverrides extensionOverrides = new GraphFieldOverrides(extensionId, null, null);
+
+        try (GraphConnector extensionConnector = new GraphConnector(config, token, extensionOverrides)) {
+            List<Group> groups = extensionConnector.getGroups(groupPrefix);
+            assertThat(groups).isNotEmpty();
+            Group firstGroup = groups.get(0);
+            log("--- verifying per-user path against group " + firstGroup.getId() + " ---");
+
+            int before = extensionConnector.getRequestCount();
+            List<Member> members = extensionConnector.getMembers(firstGroup.getId());
+            int delta = extensionConnector.getRequestCount() - before;
+
+            log("  members resolved = " + members.size());
+            log("  Graph requests   = " + delta + " (expected " + (1 + members.size()) + ")");
+
+            assertThat(members).isNotEmpty();
+            assertThat(delta)
+                    .as("per-user path must use one list call + %d per-user calls", members.size())
+                    .isEqualTo(1 + members.size());
+            // Sanity: the extension values must actually come back resolved, otherwise the
+            // request-count assertion alone would also pass on a broken per-user implementation
+            // that returned Members with null ids.
+            assertThat(members)
+                    .allSatisfy(m -> assertThat(m.getId())
+                            .as("extension value must be resolved via /users/{id}")
+                            .isNotBlank());
+        }
+    }
+
     @Test
     void getOrganizationDataReturnsTenantInfo() {
         // Sanity check that Organization.Read.All is admin-consented and the /organization

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
@@ -285,6 +285,23 @@ class GraphConnectorTest {
     }
 
     @Test
+    void getRequestCountTracksGraphCallCount(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
+        // The counter is exposed on IGraphConnector so the job can log total Graph load and
+        // integration tests can verify batch-vs-per-user routing. Starts at 0, increments once
+        // per logical fetchMSGraphApi call.
+        mockGetGroupsCall("groups.json", 200);
+        GraphConnector connector = createConnector(wmRuntimeInfo);
+
+        assertThat(connector.getRequestCount()).isZero();
+
+        connector.getGroups(groupPrefix);
+        assertThat(connector.getRequestCount()).isEqualTo(1);
+
+        connector.getGroups(groupPrefix);
+        assertThat(connector.getRequestCount()).isEqualTo(2);
+    }
+
+    @Test
     void publicConstructorsInitializeConnectorWithoutThrowing() {
         // Exercises the production public constructors (the @VisibleForTesting variant is used
         // everywhere else in this suite). Only the construction path matters; the actual Graph

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
@@ -107,7 +107,6 @@ class GraphConnectorTest {
     void getMembers(String pathToJson, Integer expectedSize, WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
         String memberId = "memberId";
         mockGetMemberCall(memberId, pathToJson, 200);
-        stubAnyUserCallWithMailNickname();
 
         List<Member> memberList = createConnector(wmRuntimeInfo).getMembers(memberId);
 
@@ -120,7 +119,6 @@ class GraphConnectorTest {
         String baseUrl = wmRuntimeInfo.getHttpBaseUrl();
         mockGetMemberCallWithBody(memberId, getContent("groupMemberIdsPaginated.json").replace("http://localhost:1080", baseUrl), 200);
         mockGetMemberCall("next", "groupMemberIds.json", 200);
-        stubAnyUserCallWithMailNickname();
 
         List<Member> memberList = createConnector(wmRuntimeInfo).getMembers(memberId);
 
@@ -198,7 +196,8 @@ class GraphConnectorTest {
         // token via authentication.xml <mapping><id>sbbuid</id></mapping>. In Microsoft Graph the
         // same logical identifier is stored in the standard built-in property
         // onPremisesSamAccountName — a completely different name. The graphIdField override lets
-        // the operator decouple the two without touching authentication.xml.
+        // the operator decouple the two without touching authentication.xml. All resolved fields
+        // are flat, so this routes through the batch path.
         String groupKey = "myGroup";
         String aadObjectId = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
         String oauth2ClaimName = "megauid";
@@ -207,15 +206,15 @@ class GraphConnectorTest {
 
         FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration(oauth2ClaimName, "displayName", "mail");
 
-        String groupBody = "{\"value\":[{\"@odata.type\":\"#microsoft.graph.user\",\"id\":\"" + aadObjectId + "\"}]}";
-        mockGetMemberCallWithBody(groupKey, groupBody, 200);
-
-        // /users/{id} responds with the Graph property name, not the OAuth2 claim name
-        String userBody = "{\"@odata.type\":\"#microsoft.graph.user\","
+        // The /groups/{id}/members batch response carries the fully-resolved user fields inline.
+        String groupBody = "{\"value\":[{"
+                + "\"@odata.type\":\"#microsoft.graph.user\","
+                + "\"id\":\"" + aadObjectId + "\","
                 + "\"" + graphPropertyName + "\":\"" + userValue + "\","
                 + "\"displayName\":\"Override User\","
-                + "\"mail\":\"override.user@example.com\"}";
-        mockGetUserCallWithBody(aadObjectId, userBody, 200);
+                + "\"mail\":\"override.user@example.com\""
+                + "}]}";
+        mockGetMemberCallWithBody(groupKey, groupBody, 200);
 
         GraphConnector connector = register(new GraphConnector(
                 config, "test", new GraphFieldOverrides(graphPropertyName, null, null), wmRuntimeInfo.getHttpBaseUrl()));
@@ -226,12 +225,14 @@ class GraphConnectorTest {
         assertThat(members.get(0).getName()).isEqualTo("Override User");
         assertThat(members.get(0).getEmail()).isEqualTo("override.user@example.com");
 
-        // The Graph $select must use the override (onPremisesSamAccountName), NOT the OAuth2
-        // claim name (sbbuid) from <mapping>.
+        // The Graph $select on /groups/{id}/members must carry the override (onPremisesSamAccountName),
+        // NOT the OAuth2 claim name (sbbuid). No per-user /users/{id} call is made.
         com.github.tomakehurst.wiremock.client.WireMock.verify(
-                com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor(urlPathEqualTo("/v1.0/users/" + aadObjectId))
+                com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor(urlPathEqualTo("/v1.0/groups/" + groupKey + "/members"))
                         .withQueryParam("$select", com.github.tomakehurst.wiremock.client.WireMock.containing(graphPropertyName))
                         .withQueryParam("$select", com.github.tomakehurst.wiremock.client.WireMock.notContaining(oauth2ClaimName)));
+        com.github.tomakehurst.wiremock.client.WireMock.verify(0,
+                com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor(urlPathMatching("/v1\\.0/users/.+")));
     }
 
     @Test
@@ -262,6 +263,25 @@ class GraphConnectorTest {
         assertThat(partial.resolveGraphField("id", "sbbuid")).isEqualTo("onPremisesSamAccountName");
         assertThat(partial.resolveGraphField("name", "displayName")).isEqualTo("displayName");
         assertThat(partial.resolveGraphField("email", "mail")).isEqualTo("mail");
+    }
+
+    @Test
+    void requiresPerUserFetchPicksBatchPathForFlatStandardProperties() {
+        // Flat standard Graph properties — all routing to batch.
+        assertThat(GraphConnector.requiresPerUserFetch("employeeId", "displayName", "mail")).isFalse();
+        assertThat(GraphConnector.requiresPerUserFetch("mailNickname", "displayName", "mail")).isFalse();
+        assertThat(GraphConnector.requiresPerUserFetch("id", null, null)).isFalse();
+    }
+
+    @Test
+    void requiresPerUserFetchPicksPerUserPathForExtensionsOrNestedPaths() {
+        // Any schema extension → per-user path (covers issue #74 edge case).
+        assertThat(GraphConnector.requiresPerUserFetch("extension_abc_sbbuid", "displayName", "mail")).isTrue();
+        assertThat(GraphConnector.requiresPerUserFetch("displayName", "extension_abc_name", "mail")).isTrue();
+        assertThat(GraphConnector.requiresPerUserFetch("displayName", "displayName", "extension_abc_email")).isTrue();
+
+        // Nested property paths (e.g. onPremisesExtensionAttributes/extensionAttribute1) → per-user.
+        assertThat(GraphConnector.requiresPerUserFetch("onPremisesExtensionAttributes/extensionAttribute1", "displayName", "mail")).isTrue();
     }
 
     @Test
@@ -428,25 +448,26 @@ class GraphConnectorTest {
     @Test
     void getMembersFiltersOutNonUserDirectoryObjects(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
         // /groups/{id}/members can return any directory object: users, nested groups, service
-        // principals, devices. Only #microsoft.graph.user ids must propagate to /users/{id} —
-        // everything else would 404 there and crash the entire job. Fixture has 6 members of
-        // mixed types; only the 3 user-typed ones should be followed up.
+        // principals, devices. Only #microsoft.graph.user entries must end up in the result —
+        // everything else would crash downstream Polarion user creation. Fixture has 6 members
+        // of mixed types; exactly the 3 user-typed ones should survive. Uses the batch path
+        // (default mapping is flat), so filtering happens on the projected /members response.
         String groupKey = "groupWithMixedMembers";
+        FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration("id", "displayName", "mail");
         mockGetMemberCall(groupKey, "groupMembersMixedTypes.json", 200);
-        stubAnyUserCallWithMailNickname();
 
-        List<Member> members = createConnector(wmRuntimeInfo).getMembers(groupKey);
+        GraphConnector connector = register(new GraphConnector(
+                config, "test", null, wmRuntimeInfo.getHttpBaseUrl()));
+        List<Member> members = connector.getMembers(groupKey);
 
         assertThat(members).hasSize(3);
-
-        // Positive proof: WireMock saw /users/{id} requests for the user ids only.
-        verify(1, getRequestedFor(urlPathEqualTo("/v1.0/users/11111111-1111-1111-1111-111111111111")));
-        verify(1, getRequestedFor(urlPathEqualTo("/v1.0/users/33333333-3333-3333-3333-333333333333")));
-        verify(1, getRequestedFor(urlPathEqualTo("/v1.0/users/66666666-6666-6666-6666-666666666666")));
-        // Negative proof: nested group / service principal / device ids must not be requested.
-        verify(0, getRequestedFor(urlPathEqualTo("/v1.0/users/22222222-2222-2222-2222-222222222222")));
-        verify(0, getRequestedFor(urlPathEqualTo("/v1.0/users/44444444-4444-4444-4444-444444444444")));
-        verify(0, getRequestedFor(urlPathEqualTo("/v1.0/users/55555555-5555-5555-5555-555555555555")));
+        assertThat(members).extracting(Member::getId).containsExactly(
+                "11111111-1111-1111-1111-111111111111",
+                "33333333-3333-3333-3333-333333333333",
+                "66666666-6666-6666-6666-666666666666");
+        // Batch path makes exactly one call to /members and no per-user calls.
+        verify(1, getRequestedFor(urlPathEqualTo("/v1.0/groups/" + groupKey + "/members")));
+        verify(0, getRequestedFor(urlPathMatching("/v1\\.0/users/.+")));
     }
 
     @Test
@@ -496,19 +517,23 @@ class GraphConnectorTest {
     }
 
     @Test
-    void getMembersParsesRealisticUserResponseWithVanillaAttributes(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
-        // Vanilla MS Graph properties: mailNickname/displayName/mail. No graphIdField overrides —
-        // the <mapping> names go straight into $select. Validates the simplest possible
-        // synchronizer configuration end-to-end through the parser.
+    void getMembersParsesRealisticUserResponseWithVanillaAttributes(WireMockRuntimeInfo wmRuntimeInfo) {
+        // Vanilla MS Graph properties: mailNickname/displayName/mail. All flat → batch path.
+        // Validates that the projected user fields are picked up inline from the /members response.
         String groupKey = "myGroup";
         String aadObjectId = "11111111-1111-1111-1111-111111111111";
 
         // Default FakeOAuth2SecurityConfiguration() uses mailNickname/displayName/mail.
         FakeOAuth2SecurityConfiguration config = new FakeOAuth2SecurityConfiguration();
 
-        String groupBody = "{\"value\":[{\"@odata.type\":\"#microsoft.graph.user\",\"id\":\"" + aadObjectId + "\"}]}";
+        String groupBody = "{\"value\":[{"
+                + "\"@odata.type\":\"#microsoft.graph.user\","
+                + "\"id\":\"" + aadObjectId + "\","
+                + "\"mailNickname\":\"john.doe\","
+                + "\"displayName\":\"John Doe\","
+                + "\"mail\":\"john.doe@example.com\""
+                + "}]}";
         mockGetMemberCallWithBody(groupKey, groupBody, 200);
-        mockGetUserCallWithBody(aadObjectId, getContent("userWithVanillaAttributes.json"), 200);
 
         GraphConnector connector = register(new GraphConnector(config, "test", null, wmRuntimeInfo.getHttpBaseUrl()));
         List<Member> members = connector.getMembers(groupKey);
@@ -518,6 +543,8 @@ class GraphConnectorTest {
         assertThat(member.getId()).isEqualTo("john.doe");
         assertThat(member.getName()).isEqualTo("John Doe");
         assertThat(member.getEmail()).isEqualTo("john.doe@example.com");
+        // Single batch call, no per-user calls.
+        verify(0, getRequestedFor(urlPathMatching("/v1\\.0/users/.+")));
     }
 
     @Test
@@ -635,22 +662,6 @@ class GraphConnectorTest {
                         .withStatus(statusCode)
                         .withHeader("Content-Type", "application/json; charset=utf-8")
                         .withBody(body)));
-    }
-
-    /**
-     * Stubs every {@code /v1.0/users/{id}} request with a response containing the standard
-     * mailNickname/displayName/mail fields the default {@link FakeOAuth2SecurityConfiguration} expects.
-     * Used by tests that don't care about per-user details, only that the right number of members is returned.
-     */
-    private void stubAnyUserCallWithMailNickname() {
-        stubFor(get(urlPathMatching("/v1\\.0/users/.+"))
-                .willReturn(aResponse()
-                        .withStatus(200)
-                        .withHeader("Content-Type", "application/json; charset=utf-8")
-                        .withBody("{\"@odata.type\":\"#microsoft.graph.user\","
-                                + "\"mailNickname\":\"someUser\","
-                                + "\"displayName\":\"Some User\","
-                                + "\"mail\":\"some.user@example.com\"}")));
     }
 
     private String getContent(String path) throws IOException {

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/IGraphConnectorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/IGraphConnectorTest.java
@@ -1,0 +1,38 @@
+package ch.sbb.polarion.extension.aad.synchronizer.connector;
+
+import ch.sbb.polarion.extension.aad.synchronizer.model.Group;
+import ch.sbb.polarion.extension.aad.synchronizer.model.Member;
+import ch.sbb.polarion.extension.aad.synchronizer.model.OrganizationData;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IGraphConnectorTest {
+
+    @Test
+    void defaultRequestCountIsZeroForImplementationsThatDoNotTrackRequests() {
+        // External IGraphConnector implementations registered via OSGi are not required to
+        // implement the request-count API. The interface provides a default of 0 which the job
+        // logger treats as "unavailable" (suppresses the summary line).
+        IGraphConnector connector = new IGraphConnector() {
+            @Override
+            public List<Group> getGroups(String groupPrefix) {
+                return List.of();
+            }
+
+            @Override
+            public List<Member> getMembers(String key) {
+                return List.of();
+            }
+
+            @Override
+            public OrganizationData getOrganizationData() {
+                return null;
+            }
+        };
+
+        assertThat(connector.getRequestCount()).isZero();
+    }
+}


### PR DESCRIPTION
### Proposed changes

This pull request significantly refactors how group member resolution is handled in the `GraphConnector`, introducing a smart switch between batch and per-user fetch paths for Microsoft Graph API calls. The new logic optimizes for the common case where all requested fields are standard, using a single batch request, and only falls back to per-user calls when necessary (e.g., for schema extensions or nested property paths). The changes are thoroughly tested, including integration and unit tests, and improve both performance and correctness.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
