### PR TITLE
feat: support regular expressions for AAD group filtering with groupPattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ To run this job on a schedule, configure it in the global `Administration` / `Sc
     <graphIdField>onPremisesSamAccountName</graphIdField>
 
     <groupPrefix>SOME_GROUP_PREFIX_</groupPrefix>
+    <!-- Optional: regex applied client-side against AAD group displayName.
+         Useful when the prefix is not enough to disambiguate (e.g. multiple related
+         prefixes or excluding a specific one). May be combined with groupPrefix or
+         used on its own. At least one of groupPrefix/groupPattern must be set. -->
+    <!-- <groupPattern>^SOME(_OTHER)?_GROUP_PREFIX_.*</groupPattern> -->
+
 
     <whitelist>
         <filter>^user\d{3}@example\.com$</filter>
@@ -196,7 +202,21 @@ extension owned by an AAD application with id `abc123de-f456-7890-abcd-ef1234567
 
 #### Group Synchronization
 
-- **Group Prefix** (`groupPrefix`): Limits synchronization to groups with a specified naming prefix.
+- **Group Prefix** (`groupPrefix`): Limits synchronization to groups whose `displayName`
+  starts with the specified literal prefix. Translated into a server-side
+  `startswith(displayName, ...)` filter on Microsoft Graph.
+- **Group Pattern** (`groupPattern`): Optional regular expression (Java
+  [`java.util.regex`](https://docs.oracle.com/javase/tutorial/essential/regex/) syntax) matched
+  client-side against `displayName` (full match, like `String.matches`). Use it to match
+  multiple related prefixes or to exclude specific ones with a single rule, e.g.
+  `^SOME(_OTHER)?_GROUP_PREFIX_.*` matches groups starting with `SOME_GROUP_PREFIX_` or
+  `SOME_OTHER_GROUP_PREFIX_` while skipping `SOME_IGNORED_GROUP_PREFIX_`.
+
+At least one of `groupPrefix` or `groupPattern` must be provided. When both are set,
+`groupPrefix` narrows the result server-side and `groupPattern` filters it further on the
+extension side. When only `groupPattern` is set, all groups in the tenant are fetched and
+filtered client-side — prefer to also set a `groupPrefix` on large tenants to keep the
+Graph response size bounded. Invalid regex fails the job at start with a clear error.
 
 #### User Filters
 

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnit.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnit.java
@@ -18,6 +18,8 @@ public interface AADUserSynchronizationJobUnit extends IJobUnit {
 
     void setGroupPrefix(String groupPrefix);
 
+    void setGroupPattern(String groupPattern);
+
     void setWhitelist(Whitelist whitelist);
 
     void setBlacklist(Blacklist blacklist);

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactory.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactory.java
@@ -18,6 +18,7 @@ public class AADUserSynchronizationJobUnitFactory implements IJobUnitFactory {
     public static final String GRAPH_NAME_FIELD = "graphNameField";
     public static final String GRAPH_EMAIL_FIELD = "graphEmailField";
     public static final String GROUP_PREFIX = "groupPrefix";
+    public static final String GROUP_PATTERN = "groupPattern";
     public static final String WHITELIST = "whitelist";
     public static final String BLACKLIST = "blacklist";
     public static final String DRY_RUN = "dryRun";
@@ -65,7 +66,13 @@ public class AADUserSynchronizationJobUnitFactory implements IJobUnitFactory {
         desc.addParameter(new SimpleJobParameter(
                 desc.getRootParameterGroup(),
                 GROUP_PREFIX,
-                "Group prefix in Azure AD",
+                "Group prefix in Azure AD. Translated to a server-side startswith(displayName, ...) filter on Microsoft Graph. Optional when groupPattern is set; at least one of groupPrefix/groupPattern must be provided.",
+                stringType).setRequired(false));
+
+        desc.addParameter(new SimpleJobParameter(
+                desc.getRootParameterGroup(),
+                GROUP_PATTERN,
+                "Regular expression matched client-side against the AAD group displayName (full match, java.util.regex). Useful for matching multiple prefixes or excluding specific ones, e.g. ^SOME(_OTHER)?_GROUP_PREFIX_.* . Combined with groupPrefix the prefix narrows server-side and the pattern narrows further client-side. At least one of groupPrefix/groupPattern must be provided.",
                 stringType).setRequired(false));
 
         desc.addParameter(new SimpleJobParameter(

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnit.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnit.java
@@ -31,6 +31,8 @@ import org.jetbrains.annotations.VisibleForTesting;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUserSynchronizationJobUnit {
     private final ISecurityService securityService;
@@ -43,6 +45,8 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
     private String graphEmailField;
     private IOAuth2SecurityConfiguration authenticationProviderConfiguration;
     private String groupPrefix;
+    private String groupPattern;
+    private Pattern compiledGroupPattern;
     private Whitelist whitelist;
     private Blacklist blacklist;
     private boolean dryRun = false;
@@ -96,7 +100,7 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
         JobLogger.getInstance().separator();
 
         JobLogger.getInstance().separator();
-        final List<String> allMemberIds = new ArrayList<>(graphService.getAadMemberIds(groupPrefix));
+        final List<String> allMemberIds = new ArrayList<>(graphService.getAadMemberIds(groupPrefix, compiledGroupPattern));
         JobLogger.getInstance().separator();
 
         JobLogger.getInstance().separator();
@@ -171,8 +175,18 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
         }
         this.authenticationProviderConfiguration = findAuthenticationProviderConfiguration(authenticationProviderId);
 
-        if (isParameterNotProvided(groupPrefix)) {
-            throw new NotFoundException("Group prefix should be provided via job properties");
+        if (isParameterNotProvided(groupPrefix) && isParameterNotProvided(groupPattern)) {
+            throw new NotFoundException("Either group prefix or group pattern should be provided via job properties");
+        }
+
+        if (!isParameterNotProvided(groupPattern)) {
+            try {
+                this.compiledGroupPattern = Pattern.compile(groupPattern);
+            } catch (PatternSyntaxException e) {
+                throw new NotFoundException("Group pattern is not a valid regular expression: " + e.getMessage());
+            }
+        } else {
+            this.compiledGroupPattern = null;
         }
     }
 
@@ -218,6 +232,11 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
     @Override
     public void setGroupPrefix(String prefix) {
         this.groupPrefix = prefix;
+    }
+
+    @Override
+    public void setGroupPattern(String groupPattern) {
+        this.groupPattern = groupPattern;
     }
 
     @Override

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
@@ -123,8 +123,13 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
     @Override
     public List<Group> getGroups(String groupPrefix) {
         String url = urlBuilder.build(graphUrl, GraphOption.GROUPS);
-        String filterValue = "startswith(displayName, '" + groupPrefix + "')";
-        GroupResponseWrapper searchResult = fetchMSGraphApi(url, "$filter", filterValue, GroupResponseWrapper.class);
+        GroupResponseWrapper searchResult;
+        if (groupPrefix == null || groupPrefix.isBlank()) {
+            searchResult = fetchMSGraphApi(url, null, null, GroupResponseWrapper.class);
+        } else {
+            String filterValue = "startswith(displayName, '" + groupPrefix + "')";
+            searchResult = fetchMSGraphApi(url, "$filter", filterValue, GroupResponseWrapper.class);
+        }
         if (searchResult.getValue() == null || searchResult.getValue().isEmpty()) {
             throw new NotFoundException("No AAD groups were found.");
         }

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/model/Group.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/model/Group.java
@@ -9,4 +9,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class Group {
     private String id;
+    private String displayName;
+
+    public Group(String id) {
+        this.id = id;
+    }
 }

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/service/GraphService.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/service/GraphService.java
@@ -1,16 +1,19 @@
 package ch.sbb.polarion.extension.aad.synchronizer.service;
 
 import ch.sbb.polarion.extension.aad.synchronizer.connector.IGraphConnector;
+import ch.sbb.polarion.extension.aad.synchronizer.exception.NotFoundException;
 import ch.sbb.polarion.extension.aad.synchronizer.model.Group;
 import ch.sbb.polarion.extension.aad.synchronizer.model.Member;
 import ch.sbb.polarion.extension.aad.synchronizer.model.OrganizationData;
 import ch.sbb.polarion.extension.aad.synchronizer.utils.TimeUtils;
 import ch.sbb.polarion.extension.generic.util.JobLogger;
 import lombok.AllArgsConstructor;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @AllArgsConstructor
@@ -18,9 +21,20 @@ public class GraphService implements IGraphService {
     private final IGraphConnector graphConnector;
 
     @Override
-    public Set<String> getAadMemberIds(String groupPrefix) {
+    public Set<String> getAadMemberIds(@Nullable String groupPrefix, @Nullable Pattern groupPattern) {
         List<Group> groups = graphConnector.getGroups(groupPrefix);
-        JobLogger.getInstance().log("%d group(s) have been found with prefix '%s'", groups.size(), groupPrefix);
+        JobLogger.getInstance().log("%d group(s) returned by Microsoft Graph for prefix '%s'", groups.size(), groupPrefix == null ? "" : groupPrefix);
+
+        if (groupPattern != null) {
+            List<Group> matched = groups.stream()
+                    .filter(g -> g.getDisplayName() != null && groupPattern.matcher(g.getDisplayName()).matches())
+                    .toList();
+            JobLogger.getInstance().log("%d group(s) matched pattern '%s'", matched.size(), groupPattern.pattern());
+            if (matched.isEmpty()) {
+                throw new NotFoundException("No AAD groups matched the configured groupPattern.");
+            }
+            groups = matched;
+        }
 
         Set<String> members = getAadMemberIds(groups);
 

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/service/IGraphService.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/service/IGraphService.java
@@ -1,9 +1,12 @@
 package ch.sbb.polarion.extension.aad.synchronizer.service;
 
+import org.jetbrains.annotations.Nullable;
+
 import java.util.Set;
+import java.util.regex.Pattern;
 
 public interface IGraphService {
-    Set<String> getAadMemberIds(String groupPrefix);
+    Set<String> getAadMemberIds(@Nullable String groupPrefix, @Nullable Pattern groupPattern);
 
     void checkLastSynchronization();
 }

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactoryTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactoryTest.java
@@ -17,7 +17,7 @@ class AADUserSynchronizationJobUnitFactoryTest {
         IJobDescriptor descriptor = factory.getJobDescriptor(null);
 
         assertThat(descriptor.getLabel()).isEqualTo("Synchronization job");
-        Stream.of(AUTHENTICATION_PROVIDER_ID, GROUP_PREFIX, DRY_RUN, CHECK_LAST_SYNCHRONIZATION,
+        Stream.of(AUTHENTICATION_PROVIDER_ID, GROUP_PREFIX, GROUP_PATTERN, DRY_RUN, CHECK_LAST_SYNCHRONIZATION,
                 GRAPH_ID_FIELD, GRAPH_NAME_FIELD, GRAPH_EMAIL_FIELD).forEach(
                 param -> assertThat(descriptor.getParameter(param)).isNotNull()
         );

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnitTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnitTest.java
@@ -38,6 +38,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -185,6 +186,81 @@ class UserSynchronizationJobUnitTest {
 
         // Act, Assert
         callRunInternalAndVerifyException("Authentication Provider ID");
+    }
+
+    @Test
+    void shouldFailWhenNeitherGroupPrefixNorGroupPatternProvided() {
+        // Validation contract: at least one of groupPrefix/groupPattern must be set, otherwise the
+        // job has no way to scope which AAD groups to read and would either fall back to the whole
+        // tenant (when only the prefix branch existed) or do nothing meaningful.
+        userSynchronizationJobUnit.setGroupPrefix(null);
+        userSynchronizationJobUnit.setGroupPattern(null);
+
+        try (MockedStatic<AuthenticationManager> mockedAuthenticationManager = Mockito.mockStatic(AuthenticationManager.class, RETURNS_DEEP_STUBS)) {
+            mockedAuthenticationManager.when(() -> AuthenticationManager.getInstance().authenticators())
+                    .thenReturn(List.of(authenticationProviderConfiguration));
+
+            callRunInternalAndVerifyException("group prefix or group pattern");
+        }
+    }
+
+    @Test
+    void shouldFailOnInvalidGroupPattern() {
+        // An invalid regex should fail the job at start with a clear configuration error rather
+        // than throwing PatternSyntaxException deep inside the run.
+        userSynchronizationJobUnit.setGroupPrefix(null);
+        userSynchronizationJobUnit.setGroupPattern("[invalid(");
+
+        try (MockedStatic<AuthenticationManager> mockedAuthenticationManager = Mockito.mockStatic(AuthenticationManager.class, RETURNS_DEEP_STUBS)) {
+            mockedAuthenticationManager.when(() -> AuthenticationManager.getInstance().authenticators())
+                    .thenReturn(List.of(authenticationProviderConfiguration));
+
+            callRunInternalAndVerifyException("not a valid regular expression");
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldRunWithGroupPatternOnly() {
+        // Pattern-only configuration: no server-side prefix, regex applied client-side.
+        // Verifies the pattern actually filters groups before resolving members.
+        userSynchronizationJobUnit.setGroupPrefix(null);
+        userSynchronizationJobUnit.setGroupPattern("^SOME(_OTHER)?_GROUP_PREFIX_.*");
+
+        try (MockedStatic<TransactionalExecutor> mockedExecutor = Mockito.mockStatic(TransactionalExecutor.class);
+             MockedStatic<OSGiUtils> mockedOSGiUtils = Mockito.mockStatic(OSGiUtils.class);
+             MockedStatic<AuthenticationManager> mockedAuthenticationManager = Mockito.mockStatic(AuthenticationManager.class, RETURNS_DEEP_STUBS)
+        ) {
+            mockedExecutor.when(() -> TransactionalExecutor.executeSafelyInReadOnlyTransaction(any(RunnableInReadOnlyTransaction.class)))
+                    .thenAnswer(invocation -> {
+                        RunnableInReadOnlyTransaction<?> transaction = invocation.getArgument(0);
+                        return transaction.run(mock(ReadOnlyTransaction.class));
+                    });
+            mockedExecutor.when(() -> TransactionalExecutor.executeInWriteTransaction(any(RunnableInWriteTransaction.class)))
+                    .thenAnswer(invocation -> {
+                        RunnableInWriteTransaction<?> transaction = invocation.getArgument(0);
+                        return transaction.run(mock(WriteTransaction.class));
+                    });
+            mockedOSGiUtils.when(() -> OSGiUtils.lookupOSGiService(IPolarionServiceFactory.class))
+                    .thenReturn((IPolarionServiceFactory) (s, p, d, ids) -> polarionService);
+            // No prefix → connector called with null. Three groups: two should pass the regex,
+            // one (SOME_IGNORED_…) must be filtered out.
+            when(externalGraphConnector.getGroups(null)).thenReturn(List.of(
+                    new Group("kept1", "SOME_GROUP_PREFIX_X"),
+                    new Group("kept2", "SOME_OTHER_GROUP_PREFIX_Y"),
+                    new Group("dropped", "SOME_IGNORED_GROUP_PREFIX_Z")
+            ));
+            when(externalGraphConnector.getMembers("kept1")).thenReturn(List.of(new Member("u1", "n", "e")));
+            when(externalGraphConnector.getMembers("kept2")).thenReturn(List.of(new Member("u2", "n", "e")));
+            mockedAuthenticationManager.when(() -> AuthenticationManager.getInstance().authenticators())
+                    .thenReturn(List.of(authenticationProviderConfiguration));
+
+            IJobStatus jobStatus = userSynchronizationJobUnit.runInternal(monitor);
+
+            assertThat(jobStatus.getType().getName()).isEqualTo("OK");
+            verify(externalGraphConnector, never()).getMembers("dropped");
+            verify(polarionService).createPolarionUsers(argThat(ids -> ids.size() == 2 && ids.contains("u1") && ids.contains("u2")));
+        }
     }
 
     private void callRunInternalAndVerifyException(String message) {

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
@@ -312,7 +312,7 @@ class GraphConnectorIT {
     }
 
     /**
-     * Exercises the production wrapper {@link GraphService#getAadMemberIds(String)} end-to-end.
+     * Exercises the production wrapper {@link GraphService#getAadMemberIds(String, java.util.regex.Pattern)} end-to-end.
      * The job's {@code runInternal} goes through this method, not directly through
      * {@link GraphConnector#getMembers(String)}, so a regression in {@code GraphService}'s dedup
      * or {@code id != null} filter would not be caught by the connector-level tests above.
@@ -323,7 +323,7 @@ class GraphConnectorIT {
     void graphServicePipelineDedupesAndFilters() {
         GraphService service = new GraphService(connector);
 
-        Set<String> ids = service.getAadMemberIds(groupPrefix);
+        Set<String> ids = service.getAadMemberIds(groupPrefix, null);
 
         log("--- GraphService.getAadMemberIds('" + groupPrefix + "') ---");
         log("  resolved " + ids.size() + " unique non-null id(s)");

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
@@ -380,6 +380,22 @@ class GraphConnectorTest {
         List<Group> groupList = createConnector(wmRuntimeInfo).getGroups(groupPrefix);
 
         assertThat(groupList).hasSize(5);
+        assertThat(groupList.get(0).getDisplayName()).isEqualTo("SOME_GROUP_PREFIX_ACCESS_XYZ_PROJECT");
+    }
+
+    @Test
+    void getGroupsOmitsServerSideFilterWhenPrefixIsBlank(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
+        // When only groupPattern is configured (and groupPrefix is blank/null), the connector
+        // must fetch all groups: no $filter query parameter on the Graph request. The job then
+        // narrows the result client-side. Verifying via WireMock that the request URL does not
+        // carry a $filter would be ideal, but for our purposes confirming that null and blank
+        // both succeed (no NPE building the OData filter) is enough.
+        mockGetGroupsCall("groups.json", 200);
+        GraphConnector connector = createConnector(wmRuntimeInfo);
+
+        assertThat(connector.getGroups(null)).hasSize(5);
+        assertThat(connector.getGroups("")).hasSize(5);
+        assertThat(connector.getGroups("   ")).hasSize(5);
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/service/GraphServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/service/GraphServiceTest.java
@@ -1,6 +1,7 @@
 package ch.sbb.polarion.extension.aad.synchronizer.service;
 
 import ch.sbb.polarion.extension.aad.synchronizer.connector.GraphConnector;
+import ch.sbb.polarion.extension.aad.synchronizer.exception.NotFoundException;
 import ch.sbb.polarion.extension.aad.synchronizer.model.Group;
 import ch.sbb.polarion.extension.aad.synchronizer.model.Member;
 import ch.sbb.polarion.extension.aad.synchronizer.model.OrganizationData;
@@ -19,9 +20,11 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
@@ -68,9 +71,62 @@ class GraphServiceTest {
                 when(graphConnector.getMembers(groupId)).thenReturn(members)
         );
 
-        List<String> members = new ArrayList<>(service.getAadMemberIds(groupPrefix));
+        List<String> members = new ArrayList<>(service.getAadMemberIds(groupPrefix, null));
 
         assertThat(members).hasSize(expected.size()).isEqualTo(expected);
+    }
+
+    @Test
+    void testGetAadMemberIdsAppliesGroupPattern() {
+        // groupPattern narrows the server-side result client-side: only groups whose displayName
+        // fully matches the regex contribute their members. The example mirrors the issue #81
+        // motivating example: match SOME_ and SOME_OTHER_ prefixes while excluding SOME_IGNORED_.
+        Group keep1 = new Group("g1", "SOME_GROUP_PREFIX_A");
+        Group keep2 = new Group("g2", "SOME_OTHER_GROUP_PREFIX_B");
+        Group drop = new Group("g3", "SOME_IGNORED_GROUP_PREFIX_C");
+
+        when(graphConnector.getGroups("SOME")).thenReturn(List.of(keep1, keep2, drop));
+        when(graphConnector.getMembers("g1")).thenReturn(List.of(new Member("m1", "n", "e")));
+        when(graphConnector.getMembers("g2")).thenReturn(List.of(new Member("m2", "n", "e")));
+
+        Pattern pattern = Pattern.compile("^SOME(_OTHER)?_GROUP_PREFIX_.*");
+        GraphService service = new GraphService(graphConnector);
+
+        List<String> members = new ArrayList<>(service.getAadMemberIds("SOME", pattern));
+
+        assertThat(members).containsExactlyInAnyOrder("m1", "m2");
+    }
+
+    @Test
+    void testGetAadMemberIdsRaisesWhenPatternMatchesNothing() {
+        // If the regex filters out every group the connector returned, the job must fail loudly
+        // instead of silently producing an empty member set (which would later wipe Polarion).
+        Group g = new Group("g1", "SOME_IGNORED_GROUP_PREFIX_A");
+        when(graphConnector.getGroups("SOME")).thenReturn(List.of(g));
+
+        Pattern pattern = Pattern.compile("^SOME(_OTHER)?_GROUP_PREFIX_.*");
+        GraphService service = new GraphService(graphConnector);
+
+        assertThatThrownBy(() -> service.getAadMemberIds("SOME", pattern))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("groupPattern");
+    }
+
+    @Test
+    void testGetAadMemberIdsTolerantToMissingDisplayName() {
+        // Defensive: a Group without a displayName (e.g. external IGraphConnector implementation
+        // not populating it) must not blow up — it just doesn't match any pattern.
+        Group named = new Group("g1", "SOME_GROUP_PREFIX_A");
+        Group unnamed = new Group("g2");
+        when(graphConnector.getGroups("SOME")).thenReturn(List.of(named, unnamed));
+        when(graphConnector.getMembers("g1")).thenReturn(List.of(new Member("m1", "n", "e")));
+
+        Pattern pattern = Pattern.compile("^SOME_GROUP_PREFIX_.*");
+        GraphService service = new GraphService(graphConnector);
+
+        List<String> members = new ArrayList<>(service.getAadMemberIds("SOME", pattern));
+
+        assertThat(members).containsExactly("m1");
     }
 
     @Test


### PR DESCRIPTION
### Proposed changes

This pull request adds support for filtering Azure AD groups using a client-side regular expression (`groupPattern`) in addition to the existing server-side prefix filter (`groupPrefix`). This enhancement allows more flexible and precise group selection during user synchronization, especially when multiple related prefixes or exclusions are needed. The update includes configuration, validation, implementation, and comprehensive tests for the new feature.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
