### PR TITLE
feat: introduce support for multiple group prefixes and patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,29 @@ To run this job on a schedule, configure it in the global `Administration` / `Sc
          (see "Overriding Graph property names per mapping field" below) -->
     <graphIdField>onPremisesSamAccountName</graphIdField>
 
-    <groupPrefix>SOME_GROUP_PREFIX_</groupPrefix>
-    <!-- Optional: regex applied client-side against AAD group displayName.
-         Useful when the prefix is not enough to disambiguate (e.g. multiple related
-         prefixes or excluding a specific one). May be combined with groupPrefix or
-         used on its own. At least one of groupPrefix/groupPattern must be set. -->
-    <!-- <groupPattern>^SOME(_OTHER)?_GROUP_PREFIX_.*</groupPattern> -->
+    <!-- One literal prefix — translated to startswith(displayName, ...) on Microsoft Graph. -->
+    <groupPrefixes>
+        <groupPrefix>SOME_GROUP_PREFIX_</groupPrefix>
+    </groupPrefixes>
+
+    <!-- Multiple disjoint prefixes are OR-combined into one Graph $filter request:
+         startswith(displayName, 'LEGACY_') or startswith(displayName, 'NEW_')
+         Up to 15 prefixes are accepted; Graph rejects larger expressions with HTTP 400. -->
+    <!--
+    <groupPrefixes>
+        <groupPrefix>LEGACY_</groupPrefix>
+        <groupPrefix>NEW_</groupPrefix>
+    </groupPrefixes>
+    -->
+
+    <!-- Optional: regex list applied client-side against AAD group displayName (full match).
+         A group is included when ANY pattern matches. Combined with groupPrefixes the prefixes
+         narrow the result server-side and the patterns narrow further client-side. -->
+    <!--
+    <groupPatterns>
+        <groupPattern>^SOME(_OTHER)?_GROUP_PREFIX_.*</groupPattern>
+    </groupPatterns>
+    -->
 
 
     <whitelist>
@@ -202,21 +219,37 @@ extension owned by an AAD application with id `abc123de-f456-7890-abcd-ef1234567
 
 #### Group Synchronization
 
-- **Group Prefix** (`groupPrefix`): Limits synchronization to groups whose `displayName`
-  starts with the specified literal prefix. Translated into a server-side
-  `startswith(displayName, ...)` filter on Microsoft Graph.
-- **Group Pattern** (`groupPattern`): Optional regular expression (Java
-  [`java.util.regex`](https://docs.oracle.com/javase/tutorial/essential/regex/) syntax) matched
-  client-side against `displayName` (full match, like `String.matches`). Use it to match
-  multiple related prefixes or to exclude specific ones with a single rule, e.g.
-  `^SOME(_OTHER)?_GROUP_PREFIX_.*` matches groups starting with `SOME_GROUP_PREFIX_` or
-  `SOME_OTHER_GROUP_PREFIX_` while skipping `SOME_IGNORED_GROUP_PREFIX_`.
+- **Group Prefixes** (`groupPrefixes`): A list of literal prefixes against AAD group
+  `displayName`. The job translates the list into a single Microsoft Graph request whose
+  `$filter` OR-combines `startswith(displayName, ...)` clauses for every entry. Up to 15
+  prefixes are accepted — Graph rejects larger expressions with HTTP 400, so the job
+  fails fast at start when this limit is exceeded. Use this when the relevant groups
+  share two or more disjoint naming conventions (e.g. `LEGACY_` and `NEW_`).
+- **Group Patterns** (`groupPatterns`): Optional list of regular expressions
+  ([`java.util.regex`](https://docs.oracle.com/javase/tutorial/essential/regex/) syntax,
+  full match like `String.matches`) applied client-side against `displayName`. A group is
+  included when **any** pattern matches. Useful for excluding specific prefixes, e.g.
+  `^SOME(_OTHER)?_GROUP_PREFIX_.*` matches `SOME_GROUP_PREFIX_*` and
+  `SOME_OTHER_GROUP_PREFIX_*` while skipping `SOME_IGNORED_GROUP_PREFIX_*`. Invalid regex
+  fails the job at start with a clear error and the offending pattern.
 
-At least one of `groupPrefix` or `groupPattern` must be provided. When both are set,
-`groupPrefix` narrows the result server-side and `groupPattern` filters it further on the
-extension side. When only `groupPattern` is set, all groups in the tenant are fetched and
-filtered client-side — prefer to also set a `groupPrefix` on large tenants to keep the
-Graph response size bounded. Invalid regex fails the job at start with a clear error.
+> [!WARNING]
+> The legacy single-prefix form `<groupPrefix>SOME_</groupPrefix>` is **deprecated** and
+> will be **removed in the next major release**. Migrate existing configurations to the
+> plural wrapper:
+> ```xml
+> <groupPrefixes>
+>     <groupPrefix>SOME_</groupPrefix>
+> </groupPrefixes>
+> ```
+> The two forms are mutually exclusive — set one or the other, not both. When the legacy
+> form is used, the job logs a deprecation warning at every run.
+
+At least one of `groupPrefix`, `groupPrefixes`, or `groupPatterns` must be provided. When
+prefixes and patterns are both set, prefixes narrow the result server-side and patterns
+narrow it further on the extension side. When only `groupPatterns` is set, all groups in
+the tenant are fetched and filtered client-side — prefer to also set `groupPrefixes` on
+large tenants to keep the Graph response size bounded.
 
 #### User Filters
 

--- a/aad-sync-it.properties.example
+++ b/aad-sync-it.properties.example
@@ -30,3 +30,10 @@ groupPrefix=TEST_AAD_SYNC_
 # Optional sanity check — when set, the test asserts this UPN is among the resolved members
 # of the first matching group.
 #expectedUpn=user@example.com
+
+# Opt-in flag for the <groupPatterns>-only IT path. When true, the test
+# getAadMemberIdsHandlesEmptyPrefixesWithPatternOnly fetches every group in the tenant
+# (no server-side $filter) and applies the regex client-side. Off by default — enable only
+# when the target tenant is small enough that fetching all groups is cheap. The /groups
+# endpoint paginates by 100, so a tenant with thousands of groups will issue many requests.
+#runFullTenantTest=true

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnit.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnit.java
@@ -2,6 +2,8 @@ package ch.sbb.polarion.extension.aad.synchronizer;
 
 import ch.sbb.polarion.extension.aad.synchronizer.filter.Blacklist;
 import ch.sbb.polarion.extension.aad.synchronizer.filter.Whitelist;
+import ch.sbb.polarion.extension.aad.synchronizer.model.GroupPatterns;
+import ch.sbb.polarion.extension.aad.synchronizer.model.GroupPrefixes;
 import com.polarion.platform.jobs.IJobUnit;
 
 public interface AADUserSynchronizationJobUnit extends IJobUnit {
@@ -16,9 +18,17 @@ public interface AADUserSynchronizationJobUnit extends IJobUnit {
 
     void setGraphEmailField(String graphEmailField);
 
+    /**
+     * @deprecated Legacy single-prefix form, kept only for backwards compatibility with existing
+     * job configurations. Use {@link #setGroupPrefixes(GroupPrefixes)} instead. Scheduled for
+     * removal in the next major release.
+     */
+    @Deprecated(forRemoval = true)
     void setGroupPrefix(String groupPrefix);
 
-    void setGroupPattern(String groupPattern);
+    void setGroupPrefixes(GroupPrefixes groupPrefixes);
+
+    void setGroupPatterns(GroupPatterns groupPatterns);
 
     void setWhitelist(Whitelist whitelist);
 

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactory.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactory.java
@@ -2,6 +2,8 @@ package ch.sbb.polarion.extension.aad.synchronizer;
 
 import ch.sbb.polarion.extension.aad.synchronizer.filter.Blacklist;
 import ch.sbb.polarion.extension.aad.synchronizer.filter.Whitelist;
+import ch.sbb.polarion.extension.aad.synchronizer.model.GroupPatterns;
+import ch.sbb.polarion.extension.aad.synchronizer.model.GroupPrefixes;
 import com.polarion.platform.jobs.IJobDescriptor;
 import com.polarion.platform.jobs.IJobUnit;
 import com.polarion.platform.jobs.IJobUnitFactory;
@@ -18,7 +20,8 @@ public class AADUserSynchronizationJobUnitFactory implements IJobUnitFactory {
     public static final String GRAPH_NAME_FIELD = "graphNameField";
     public static final String GRAPH_EMAIL_FIELD = "graphEmailField";
     public static final String GROUP_PREFIX = "groupPrefix";
-    public static final String GROUP_PATTERN = "groupPattern";
+    public static final String GROUP_PREFIXES = "groupPrefixes";
+    public static final String GROUP_PATTERNS = "groupPatterns";
     public static final String WHITELIST = "whitelist";
     public static final String BLACKLIST = "blacklist";
     public static final String DRY_RUN = "dryRun";
@@ -66,14 +69,36 @@ public class AADUserSynchronizationJobUnitFactory implements IJobUnitFactory {
         desc.addParameter(new SimpleJobParameter(
                 desc.getRootParameterGroup(),
                 GROUP_PREFIX,
-                "Group prefix in Azure AD. Translated to a server-side startswith(displayName, ...) filter on Microsoft Graph. Optional when groupPattern is set; at least one of groupPrefix/groupPattern must be provided.",
+                "DEPRECATED — will be removed in the next major release. Use <groupPrefixes><groupPrefix>...</groupPrefix></groupPrefixes> instead. Legacy single-prefix form, kept for backwards compatibility with existing job configurations. Translated to a server-side startswith(displayName, ...) filter on Microsoft Graph. Mutually exclusive with <groupPrefixes>. At least one of groupPrefix/groupPrefixes/groupPatterns must be provided.",
                 stringType).setRequired(false));
 
-        desc.addParameter(new SimpleJobParameter(
-                desc.getRootParameterGroup(),
-                GROUP_PATTERN,
-                "Regular expression matched client-side against the AAD group displayName (full match, java.util.regex). Useful for matching multiple prefixes or excluding specific ones, e.g. ^SOME(_OTHER)?_GROUP_PREFIX_.* . Combined with groupPrefix the prefix narrows server-side and the pattern narrows further client-side. At least one of groupPrefix/groupPattern must be provided.",
-                stringType).setRequired(false));
+        desc.addParameter(
+                new SimpleJobParameter(
+                        desc.getRootParameterGroup(),
+                        GROUP_PREFIXES,
+                        "List of literal AAD group prefixes (XML: <groupPrefixes><groupPrefix>...</groupPrefix>...</groupPrefixes>). Translated to a single Microsoft Graph $filter combining startswith(displayName, ...) clauses with OR. Up to 15 prefixes are accepted (Graph rejects larger expressions with HTTP 400). Mutually exclusive with the legacy singular <groupPrefix>.",
+                        new JobParameterPrimitiveType("GroupPrefixes", GroupPrefixes.class)
+                ) {
+                    @Override
+                    public Object convertValue(Object value) {
+                        return value instanceof Map<?, ?> map ? new GroupPrefixes(map) : null;
+                    }
+                }.setRequired(false)
+        );
+
+        desc.addParameter(
+                new SimpleJobParameter(
+                        desc.getRootParameterGroup(),
+                        GROUP_PATTERNS,
+                        "List of regular expressions matched client-side against the AAD group displayName (full match, java.util.regex). XML: <groupPatterns><groupPattern>...</groupPattern>...</groupPatterns>. A group is included if any pattern matches. Use to match disjoint prefixes or exclude specific ones, e.g. ^SOME(_OTHER)?_GROUP_PREFIX_.* . Combined with groupPrefix(es) the prefixes narrow server-side and the patterns narrow further client-side. At least one of groupPrefix/groupPrefixes/groupPatterns must be provided.",
+                        new JobParameterPrimitiveType("GroupPatterns", GroupPatterns.class)
+                ) {
+                    @Override
+                    public Object convertValue(Object value) {
+                        return value instanceof Map<?, ?> map ? new GroupPatterns(map) : null;
+                    }
+                }.setRequired(false)
+        );
 
         desc.addParameter(new SimpleJobParameter(
                 desc.getRootParameterGroup(),

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnit.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnit.java
@@ -4,9 +4,13 @@ import ch.sbb.polarion.extension.aad.synchronizer.connector.GraphConnector;
 import ch.sbb.polarion.extension.aad.synchronizer.connector.GraphFieldOverrides;
 import ch.sbb.polarion.extension.aad.synchronizer.connector.IGraphConnector;
 import ch.sbb.polarion.extension.aad.synchronizer.exception.NotFoundException;
+import ch.sbb.polarion.extension.aad.synchronizer.model.GroupPatterns;
+import ch.sbb.polarion.extension.aad.synchronizer.model.GroupPrefixes;
 import ch.sbb.polarion.extension.aad.synchronizer.filter.Blacklist;
 import ch.sbb.polarion.extension.aad.synchronizer.filter.MemberFilter;
 import ch.sbb.polarion.extension.aad.synchronizer.filter.Whitelist;
+import ch.sbb.polarion.extension.aad.synchronizer.model.GroupPatterns;
+import ch.sbb.polarion.extension.aad.synchronizer.model.GroupPrefixes;
 import ch.sbb.polarion.extension.aad.synchronizer.service.GraphService;
 import ch.sbb.polarion.extension.aad.synchronizer.service.IGraphService;
 import ch.sbb.polarion.extension.aad.synchronizer.service.IPolarionService;
@@ -30,6 +34,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.VisibleForTesting;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -45,8 +50,10 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
     private String graphEmailField;
     private IOAuth2SecurityConfiguration authenticationProviderConfiguration;
     private String groupPrefix;
-    private String groupPattern;
-    private Pattern compiledGroupPattern;
+    private GroupPrefixes groupPrefixes;
+    private GroupPatterns groupPatterns;
+    private List<String> effectivePrefixes = Collections.emptyList();
+    private List<Pattern> compiledPatterns = Collections.emptyList();
     private Whitelist whitelist;
     private Blacklist blacklist;
     private boolean dryRun = false;
@@ -78,6 +85,14 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
                 "|                    REAL RUN                   |");
         JobLogger.getInstance().separator();
 
+        if (!isParameterNotProvided(groupPrefix)) {
+            JobLogger.getInstance().log(
+                    "WARNING: <groupPrefix> is deprecated and will be removed in the next major release. "
+                            + "Migrate to <groupPrefixes><groupPrefix>%s</groupPrefix></groupPrefixes>.",
+                    groupPrefix);
+            JobLogger.getInstance().separator();
+        }
+
         if (externalGraphConnector != null) {
             JobLogger.getInstance().log("Using external graph connector: " + externalGraphConnector.getClass());
             return runWithGraphConnector(externalGraphConnector);
@@ -100,7 +115,7 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
         JobLogger.getInstance().separator();
 
         JobLogger.getInstance().separator();
-        final List<String> allMemberIds = new ArrayList<>(graphService.getAadMemberIds(groupPrefix, compiledGroupPattern));
+        final List<String> allMemberIds = new ArrayList<>(graphService.getAadMemberIds(effectivePrefixes, compiledPatterns));
         JobLogger.getInstance().separator();
 
         JobLogger.getInstance().separator();
@@ -175,19 +190,51 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
         }
         this.authenticationProviderConfiguration = findAuthenticationProviderConfiguration(authenticationProviderId);
 
-        if (isParameterNotProvided(groupPrefix) && isParameterNotProvided(groupPattern)) {
-            throw new NotFoundException("Either group prefix or group pattern should be provided via job properties");
+        boolean hasLegacyPrefix = !isParameterNotProvided(groupPrefix);
+        List<String> pluralPrefixes = groupPrefixes == null ? Collections.emptyList() : groupPrefixes.getPrefixes();
+        List<String> rawPatterns = groupPatterns == null ? Collections.emptyList() : groupPatterns.getPatterns();
+
+        if (hasLegacyPrefix && !pluralPrefixes.isEmpty()) {
+            throw new NotFoundException("Job properties contain both <groupPrefix> and <groupPrefixes>; use only one (prefer <groupPrefixes>).");
         }
 
-        if (!isParameterNotProvided(groupPattern)) {
-            try {
-                this.compiledGroupPattern = Pattern.compile(groupPattern);
-            } catch (PatternSyntaxException e) {
-                throw new NotFoundException("Group pattern is not a valid regular expression: " + e.getMessage());
-            }
-        } else {
-            this.compiledGroupPattern = null;
+        if (!hasLegacyPrefix && pluralPrefixes.isEmpty() && rawPatterns.isEmpty()) {
+            throw new NotFoundException("At least one of <groupPrefix>, <groupPrefixes>, or <groupPatterns> should be provided via job properties");
         }
+
+        if (hasLegacyPrefix) {
+            this.effectivePrefixes = List.of(groupPrefix);
+        } else {
+            // Drop blank entries so accidental empty <groupPrefix/> children in the XML don't
+            // generate broken startswith(displayName, '') clauses (which would match every group).
+            List<String> cleaned = new ArrayList<>();
+            for (String p : pluralPrefixes) {
+                if (p != null && !p.isBlank()) {
+                    cleaned.add(p);
+                }
+            }
+            this.effectivePrefixes = List.copyOf(cleaned);
+        }
+
+        if (effectivePrefixes.size() > GraphConnector.MAX_OR_GROUP_PREFIXES) {
+            throw new NotFoundException(
+                    "Too many groupPrefixes (" + effectivePrefixes.size()
+                            + "); Microsoft Graph rejects $filter expressions with more than "
+                            + GraphConnector.MAX_OR_GROUP_PREFIXES + " OR'd startswith() clauses.");
+        }
+
+        List<Pattern> compiled = new ArrayList<>(rawPatterns.size());
+        for (String raw : rawPatterns) {
+            if (raw == null || raw.isBlank()) {
+                continue;
+            }
+            try {
+                compiled.add(Pattern.compile(raw));
+            } catch (PatternSyntaxException e) {
+                throw new NotFoundException("Group pattern '" + raw + "' is not a valid regular expression: " + e.getMessage());
+            }
+        }
+        this.compiledPatterns = List.copyOf(compiled);
     }
 
     private IOAuth2SecurityConfiguration findAuthenticationProviderConfiguration(@NotNull String authenticationProviderId) {
@@ -230,13 +277,19 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
     }
 
     @Override
+    @Deprecated(forRemoval = true)
     public void setGroupPrefix(String prefix) {
         this.groupPrefix = prefix;
     }
 
     @Override
-    public void setGroupPattern(String groupPattern) {
-        this.groupPattern = groupPattern;
+    public void setGroupPrefixes(GroupPrefixes groupPrefixes) {
+        this.groupPrefixes = groupPrefixes;
+    }
+
+    @Override
+    public void setGroupPatterns(GroupPatterns groupPatterns) {
+        this.groupPatterns = groupPatterns;
     }
 
     @Override

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnit.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnit.java
@@ -4,8 +4,6 @@ import ch.sbb.polarion.extension.aad.synchronizer.connector.GraphConnector;
 import ch.sbb.polarion.extension.aad.synchronizer.connector.GraphFieldOverrides;
 import ch.sbb.polarion.extension.aad.synchronizer.connector.IGraphConnector;
 import ch.sbb.polarion.extension.aad.synchronizer.exception.NotFoundException;
-import ch.sbb.polarion.extension.aad.synchronizer.model.GroupPatterns;
-import ch.sbb.polarion.extension.aad.synchronizer.model.GroupPrefixes;
 import ch.sbb.polarion.extension.aad.synchronizer.filter.Blacklist;
 import ch.sbb.polarion.extension.aad.synchronizer.filter.MemberFilter;
 import ch.sbb.polarion.extension.aad.synchronizer.filter.Whitelist;
@@ -194,35 +192,40 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
         List<String> pluralPrefixes = groupPrefixes == null ? Collections.emptyList() : groupPrefixes.getPrefixes();
         List<String> rawPatterns = groupPatterns == null ? Collections.emptyList() : groupPatterns.getPatterns();
 
+        validateGroupSelectorsProvided(hasLegacyPrefix, pluralPrefixes, rawPatterns);
+
+        this.effectivePrefixes = resolveEffectivePrefixes(hasLegacyPrefix, pluralPrefixes);
+        this.compiledPatterns = compilePatterns(rawPatterns);
+    }
+
+    private void validateGroupSelectorsProvided(boolean hasLegacyPrefix, List<String> pluralPrefixes, List<String> rawPatterns) {
         if (hasLegacyPrefix && !pluralPrefixes.isEmpty()) {
             throw new NotFoundException("Job properties contain both <groupPrefix> and <groupPrefixes>; use only one (prefer <groupPrefixes>).");
         }
-
         if (!hasLegacyPrefix && pluralPrefixes.isEmpty() && rawPatterns.isEmpty()) {
             throw new NotFoundException("At least one of <groupPrefix>, <groupPrefixes>, or <groupPatterns> should be provided via job properties");
         }
+    }
 
+    private List<String> resolveEffectivePrefixes(boolean hasLegacyPrefix, List<String> pluralPrefixes) {
         if (hasLegacyPrefix) {
-            this.effectivePrefixes = List.of(groupPrefix);
-        } else {
-            // Drop blank entries so accidental empty <groupPrefix/> children in the XML don't
-            // generate broken startswith(displayName, '') clauses (which would match every group).
-            List<String> cleaned = new ArrayList<>();
-            for (String p : pluralPrefixes) {
-                if (p != null && !p.isBlank()) {
-                    cleaned.add(p);
-                }
-            }
-            this.effectivePrefixes = List.copyOf(cleaned);
+            return List.of(groupPrefix);
         }
-
-        if (effectivePrefixes.size() > GraphConnector.MAX_OR_GROUP_PREFIXES) {
+        // Drop blank entries so accidental empty <groupPrefix/> children in the XML don't
+        // generate broken startswith(displayName, '') clauses (which would match every group).
+        List<String> cleaned = pluralPrefixes.stream()
+                .filter(p -> p != null && !p.isBlank())
+                .toList();
+        if (cleaned.size() > GraphConnector.MAX_OR_GROUP_PREFIXES) {
             throw new NotFoundException(
-                    "Too many groupPrefixes (" + effectivePrefixes.size()
+                    "Too many groupPrefixes (" + cleaned.size()
                             + "); Microsoft Graph rejects $filter expressions with more than "
                             + GraphConnector.MAX_OR_GROUP_PREFIXES + " OR'd startswith() clauses.");
         }
+        return cleaned;
+    }
 
+    private List<Pattern> compilePatterns(List<String> rawPatterns) {
         List<Pattern> compiled = new ArrayList<>(rawPatterns.size());
         for (String raw : rawPatterns) {
             if (raw == null || raw.isBlank()) {
@@ -234,7 +237,7 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
                 throw new NotFoundException("Group pattern '" + raw + "' is not a valid regular expression: " + e.getMessage());
             }
         }
-        this.compiledPatterns = List.copyOf(compiled);
+        return List.copyOf(compiled);
     }
 
     private IOAuth2SecurityConfiguration findAuthenticationProviderConfiguration(@NotNull String authenticationProviderId) {
@@ -276,6 +279,10 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
         this.graphEmailField = graphEmailField;
     }
 
+    /**
+     * @deprecated Legacy single-prefix setter, scheduled for removal in the next major release.
+     * Use {@link #setGroupPrefixes(GroupPrefixes)} instead.
+     */
     @Override
     @Deprecated(forRemoval = true)
     public void setGroupPrefix(String prefix) {

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
@@ -120,15 +120,41 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
         return mapper;
     }
 
+    /**
+     * Maximum number of literal prefixes we are willing to OR-combine into one Microsoft Graph
+     * {@code $filter} expression. Graph rejects requests that exceed its internal complexity
+     * budget — in practice this kicks in around 15 OR clauses on {@code startswith(displayName,
+     * ...)} — with a 400 BadRequest. We cap below that and fail fast with a clear message rather
+     * than letting the OData parser surface the error.
+     */
+    public static final int MAX_OR_GROUP_PREFIXES = 15;
+
     @Override
     public List<Group> getGroups(String groupPrefix) {
+        return getGroups(groupPrefix == null || groupPrefix.isBlank() ? List.of() : List.of(groupPrefix));
+    }
+
+    @Override
+    public List<Group> getGroups(List<String> groupPrefixes) {
         String url = urlBuilder.build(graphUrl, GraphOption.GROUPS);
         GroupResponseWrapper searchResult;
-        if (groupPrefix == null || groupPrefix.isBlank()) {
+        if (groupPrefixes == null || groupPrefixes.isEmpty()) {
             searchResult = fetchMSGraphApi(url, null, null, GroupResponseWrapper.class);
         } else {
-            String filterValue = "startswith(displayName, '" + groupPrefix + "')";
-            searchResult = fetchMSGraphApi(url, "$filter", filterValue, GroupResponseWrapper.class);
+            if (groupPrefixes.size() > MAX_OR_GROUP_PREFIXES) {
+                throw new InvalidGraphResponseException(
+                        "Too many groupPrefixes (" + groupPrefixes.size()
+                                + "); Microsoft Graph rejects $filter expressions with more than "
+                                + MAX_OR_GROUP_PREFIXES + " OR'd startswith() clauses.");
+            }
+            StringBuilder filter = new StringBuilder();
+            for (int i = 0; i < groupPrefixes.size(); i++) {
+                if (i > 0) {
+                    filter.append(" or ");
+                }
+                filter.append("startswith(displayName, '").append(groupPrefixes.get(i)).append("')");
+            }
+            searchResult = fetchMSGraphApi(url, "$filter", filter.toString(), GroupResponseWrapper.class);
         }
         if (searchResult.getValue() == null || searchResult.getValue().isEmpty()) {
             throw new NotFoundException("No AAD groups were found.");

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/IGraphConnector.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/IGraphConnector.java
@@ -4,10 +4,38 @@ import ch.sbb.polarion.extension.aad.synchronizer.model.Group;
 import ch.sbb.polarion.extension.aad.synchronizer.model.Member;
 import ch.sbb.polarion.extension.aad.synchronizer.model.OrganizationData;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 
 public interface IGraphConnector {
+
+    /**
+     * Resolves AAD groups whose {@code displayName} matches any of the supplied literal prefixes.
+     * Implementations are expected to translate this into a single Microsoft Graph request with
+     * an OR'd {@code startswith(displayName, ...)} filter. An empty (or {@code null}) list means
+     * "fetch all groups" — useful when the caller intends to filter further client-side via
+     * {@code groupPatterns}.
+     *
+     * <p>The default implementation falls back to a per-prefix loop and de-duplicates by group
+     * id, preserving backwards compatibility with external {@link IGraphConnector} implementations
+     * (registered via OSGi) that only override {@link #getGroups(String)}. Our own
+     * {@code GraphConnector} overrides this method to issue a single batched request.</p>
+     */
+    default List<Group> getGroups(List<String> groupPrefixes) {
+        if (groupPrefixes == null || groupPrefixes.isEmpty()) {
+            return getGroups((String) null);
+        }
+        Map<String, Group> deduped = new LinkedHashMap<>();
+        for (String prefix : groupPrefixes) {
+            for (Group g : getGroups(prefix)) {
+                deduped.putIfAbsent(g.getId(), g);
+            }
+        }
+        return new ArrayList<>(deduped.values());
+    }
 
     List<Group> getGroups(String groupPrefix);
 

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPatterns.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPatterns.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -27,8 +28,11 @@ public class GroupPatterns {
             return;
         }
         Object value = parameters.get(GROUP_PATTERN_NAME);
-        if (value instanceof List<?>) {
-            this.patterns = List.copyOf((List<String>) value);
+        if (value instanceof List<?> list) {
+            // Defensive copy via ArrayList: tolerates null entries (which List.copyOf rejects)
+            // and decouples from the source list's mutability. UserSynchronizationJobUnit drops
+            // null/blank entries during init.
+            this.patterns = Collections.unmodifiableList(new ArrayList<>((List<String>) list));
         } else if (value instanceof String s) {
             this.patterns = List.of(s);
         } else {

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPatterns.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPatterns.java
@@ -1,0 +1,38 @@
+package ch.sbb.polarion.extension.aad.synchronizer.model;
+
+import lombok.Data;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Job-parameter wrapper for the {@code <groupPatterns>} list. Holds raw pattern strings; regex
+ * compilation is intentionally deferred to the job's initialization step so {@code
+ * PatternSyntaxException} can be reported as a configuration error against the specific offending
+ * pattern instead of failing here on the parameter conversion path.
+ */
+@Data
+public class GroupPatterns {
+    public static final String GROUP_PATTERN_NAME = "groupPattern";
+
+    private final @NotNull List<String> patterns;
+
+    @SuppressWarnings("unchecked")
+    public GroupPatterns(@Nullable Map<?, ?> parameters) {
+        if (parameters == null) {
+            this.patterns = Collections.emptyList();
+            return;
+        }
+        Object value = parameters.get(GROUP_PATTERN_NAME);
+        if (value instanceof List<?>) {
+            this.patterns = List.copyOf((List<String>) value);
+        } else if (value instanceof String s) {
+            this.patterns = List.of(s);
+        } else {
+            this.patterns = Collections.emptyList();
+        }
+    }
+}

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPatterns.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPatterns.java
@@ -27,16 +27,13 @@ public class GroupPatterns {
             this.patterns = Collections.emptyList();
             return;
         }
-        Object value = parameters.get(GROUP_PATTERN_NAME);
-        if (value instanceof List<?> list) {
-            // Defensive copy via ArrayList: tolerates null entries (which List.copyOf rejects)
-            // and decouples from the source list's mutability. UserSynchronizationJobUnit drops
-            // null/blank entries during init.
-            this.patterns = Collections.unmodifiableList(new ArrayList<>((List<String>) list));
-        } else if (value instanceof String s) {
-            this.patterns = List.of(s);
-        } else {
-            this.patterns = Collections.emptyList();
-        }
+        // Defensive copy via ArrayList for the List branch: tolerates null entries (which
+        // List.copyOf rejects) and decouples from the source list's mutability.
+        // UserSynchronizationJobUnit drops null/blank entries during init.
+        this.patterns = switch (parameters.get(GROUP_PATTERN_NAME)) {
+            case List<?> list -> Collections.unmodifiableList(new ArrayList<>((List<String>) list));
+            case String s -> List.of(s);
+            case null, default -> Collections.emptyList();
+        };
     }
 }

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPrefixes.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPrefixes.java
@@ -1,0 +1,40 @@
+package ch.sbb.polarion.extension.aad.synchronizer.model;
+
+import lombok.Data;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Job-parameter wrapper for the {@code <groupPrefixes>} list. Mirrors the {@link
+ * ch.sbb.polarion.extension.aad.synchronizer.filter.Whitelist} pattern: Polarion delivers the
+ * nested XML as a {@link Map} keyed by the inner element name (here, {@code groupPrefix}). Single
+ * children come through as a bare {@link String}; multiple children come through as a {@link
+ * List}. Both shapes collapse to a {@code List<String>} here so callers can ignore the
+ * difference.
+ */
+@Data
+public class GroupPrefixes {
+    public static final String GROUP_PREFIX_NAME = "groupPrefix";
+
+    private final @NotNull List<String> prefixes;
+
+    @SuppressWarnings("unchecked")
+    public GroupPrefixes(@Nullable Map<?, ?> parameters) {
+        if (parameters == null) {
+            this.prefixes = Collections.emptyList();
+            return;
+        }
+        Object value = parameters.get(GROUP_PREFIX_NAME);
+        if (value instanceof List<?>) {
+            this.prefixes = List.copyOf((List<String>) value);
+        } else if (value instanceof String s) {
+            this.prefixes = List.of(s);
+        } else {
+            this.prefixes = Collections.emptyList();
+        }
+    }
+}

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPrefixes.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPrefixes.java
@@ -29,16 +29,13 @@ public class GroupPrefixes {
             this.prefixes = Collections.emptyList();
             return;
         }
-        Object value = parameters.get(GROUP_PREFIX_NAME);
-        if (value instanceof List<?> list) {
-            // Defensive copy via ArrayList: tolerates null entries (which List.copyOf rejects)
-            // and decouples from the source list's mutability. UserSynchronizationJobUnit drops
-            // null/blank entries during init.
-            this.prefixes = Collections.unmodifiableList(new ArrayList<>((List<String>) list));
-        } else if (value instanceof String s) {
-            this.prefixes = List.of(s);
-        } else {
-            this.prefixes = Collections.emptyList();
-        }
+        // Defensive copy via ArrayList for the List branch: tolerates null entries (which
+        // List.copyOf rejects) and decouples from the source list's mutability.
+        // UserSynchronizationJobUnit drops null/blank entries during init.
+        this.prefixes = switch (parameters.get(GROUP_PREFIX_NAME)) {
+            case List<?> list -> Collections.unmodifiableList(new ArrayList<>((List<String>) list));
+            case String s -> List.of(s);
+            case null, default -> Collections.emptyList();
+        };
     }
 }

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPrefixes.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPrefixes.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -29,8 +30,11 @@ public class GroupPrefixes {
             return;
         }
         Object value = parameters.get(GROUP_PREFIX_NAME);
-        if (value instanceof List<?>) {
-            this.prefixes = List.copyOf((List<String>) value);
+        if (value instanceof List<?> list) {
+            // Defensive copy via ArrayList: tolerates null entries (which List.copyOf rejects)
+            // and decouples from the source list's mutability. UserSynchronizationJobUnit drops
+            // null/blank entries during init.
+            this.prefixes = Collections.unmodifiableList(new ArrayList<>((List<String>) list));
         } else if (value instanceof String s) {
             this.prefixes = List.of(s);
         } else {

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/service/GraphService.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/service/GraphService.java
@@ -8,7 +8,7 @@ import ch.sbb.polarion.extension.aad.synchronizer.model.OrganizationData;
 import ch.sbb.polarion.extension.aad.synchronizer.utils.TimeUtils;
 import ch.sbb.polarion.extension.generic.util.JobLogger;
 import lombok.AllArgsConstructor;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Objects;
@@ -21,17 +21,19 @@ public class GraphService implements IGraphService {
     private final IGraphConnector graphConnector;
 
     @Override
-    public Set<String> getAadMemberIds(@Nullable String groupPrefix, @Nullable Pattern groupPattern) {
-        List<Group> groups = graphConnector.getGroups(groupPrefix);
-        JobLogger.getInstance().log("%d group(s) returned by Microsoft Graph for prefix '%s'", groups.size(), groupPrefix == null ? "" : groupPrefix);
+    public Set<String> getAadMemberIds(@NotNull List<String> groupPrefixes, @NotNull List<Pattern> groupPatterns) {
+        List<Group> groups = graphConnector.getGroups(groupPrefixes);
+        JobLogger.getInstance().log("%d group(s) returned by Microsoft Graph for prefixes %s",
+                groups.size(), groupPrefixes.isEmpty() ? "[]" : groupPrefixes);
 
-        if (groupPattern != null) {
+        if (!groupPatterns.isEmpty()) {
             List<Group> matched = groups.stream()
-                    .filter(g -> g.getDisplayName() != null && groupPattern.matcher(g.getDisplayName()).matches())
+                    .filter(g -> g.getDisplayName() != null
+                            && groupPatterns.stream().anyMatch(p -> p.matcher(g.getDisplayName()).matches()))
                     .toList();
-            JobLogger.getInstance().log("%d group(s) matched pattern '%s'", matched.size(), groupPattern.pattern());
+            JobLogger.getInstance().log("%d group(s) matched %d pattern(s)", matched.size(), groupPatterns.size());
             if (matched.isEmpty()) {
-                throw new NotFoundException("No AAD groups matched the configured groupPattern.");
+                throw new NotFoundException("No AAD groups matched the configured groupPatterns.");
             }
             groups = matched;
         }

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/service/IGraphService.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/service/IGraphService.java
@@ -1,12 +1,13 @@
 package ch.sbb.polarion.extension.aad.synchronizer.service;
 
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
 public interface IGraphService {
-    Set<String> getAadMemberIds(@Nullable String groupPrefix, @Nullable Pattern groupPattern);
+    Set<String> getAadMemberIds(@NotNull List<String> groupPrefixes, @NotNull List<Pattern> groupPatterns);
 
     void checkLastSynchronization();
 }

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactoryTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactoryTest.java
@@ -17,7 +17,8 @@ class AADUserSynchronizationJobUnitFactoryTest {
         IJobDescriptor descriptor = factory.getJobDescriptor(null);
 
         assertThat(descriptor.getLabel()).isEqualTo("Synchronization job");
-        Stream.of(AUTHENTICATION_PROVIDER_ID, GROUP_PREFIX, GROUP_PATTERN, DRY_RUN, CHECK_LAST_SYNCHRONIZATION,
+        Stream.of(AUTHENTICATION_PROVIDER_ID, GROUP_PREFIX, GROUP_PREFIXES, GROUP_PATTERNS,
+                DRY_RUN, CHECK_LAST_SYNCHRONIZATION,
                 GRAPH_ID_FIELD, GRAPH_NAME_FIELD, GRAPH_EMAIL_FIELD).forEach(
                 param -> assertThat(descriptor.getParameter(param)).isNotNull()
         );

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactoryTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactoryTest.java
@@ -1,8 +1,13 @@
 package ch.sbb.polarion.extension.aad.synchronizer;
 
+import ch.sbb.polarion.extension.aad.synchronizer.model.GroupPatterns;
+import ch.sbb.polarion.extension.aad.synchronizer.model.GroupPrefixes;
 import com.polarion.platform.jobs.IJobDescriptor;
+import com.polarion.platform.jobs.IJobDescriptor.IJobParameter;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static ch.sbb.polarion.extension.aad.synchronizer.AADUserSynchronizationJobUnitFactory.*;
@@ -22,6 +27,40 @@ class AADUserSynchronizationJobUnitFactoryTest {
                 GRAPH_ID_FIELD, GRAPH_NAME_FIELD, GRAPH_EMAIL_FIELD).forEach(
                 param -> assertThat(descriptor.getParameter(param)).isNotNull()
         );
+    }
+
+    @Test
+    void groupPrefixesParameterConvertsMapToWrapperAndRejectsOtherShapes() {
+        // The convertValue lambda is what Polarion calls when it has finished marshalling the
+        // <groupPrefixes> XML block into a Map. Anything other than a Map (e.g. a stray String)
+        // must round-trip to null so the job's mutual-exclusion logic treats the parameter as
+        // "not provided" rather than throwing.
+        IJobParameter param = new AADUserSynchronizationJobUnitFactory()
+                .getJobDescriptor(null)
+                .getParameter(GROUP_PREFIXES);
+
+        Object converted = param.convertValue(Map.of(GroupPrefixes.GROUP_PREFIX_NAME, List.of("A_", "B_")));
+        assertThat(converted)
+                .isInstanceOfSatisfying(GroupPrefixes.class,
+                        gp -> assertThat(gp.getPrefixes()).containsExactly("A_", "B_"));
+
+        assertThat(param.convertValue("not-a-map")).isNull();
+        assertThat(param.convertValue(null)).isNull();
+    }
+
+    @Test
+    void groupPatternsParameterConvertsMapToWrapperAndRejectsOtherShapes() {
+        IJobParameter param = new AADUserSynchronizationJobUnitFactory()
+                .getJobDescriptor(null)
+                .getParameter(GROUP_PATTERNS);
+
+        Object converted = param.convertValue(Map.of(GroupPatterns.GROUP_PATTERN_NAME, "^X_.*"));
+        assertThat(converted)
+                .isInstanceOfSatisfying(GroupPatterns.class,
+                        gp -> assertThat(gp.getPatterns()).containsExactly("^X_.*"));
+
+        assertThat(param.convertValue("not-a-map")).isNull();
+        assertThat(param.convertValue(null)).isNull();
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnitTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnitTest.java
@@ -344,6 +344,61 @@ class UserSynchronizationJobUnitTest {
         }
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldDropBlankAndNullEntriesInPluralPrefixesAndPatterns() {
+        // Defensive cleanup at job init: blank/null <groupPrefix/> children produce a broken
+        // OData filter (startswith(displayName, '') matches every group), and blank/null
+        // <groupPattern/> children would compile to an empty regex and match every name. Both
+        // must be silently dropped before reaching Graph.
+        java.util.ArrayList<String> prefixesWithBlanks = new java.util.ArrayList<>();
+        prefixesWithBlanks.add("KEEP_");
+        prefixesWithBlanks.add(null);
+        prefixesWithBlanks.add("");
+        prefixesWithBlanks.add("   ");
+        java.util.ArrayList<String> patternsWithBlanks = new java.util.ArrayList<>();
+        patternsWithBlanks.add("^KEEP_.*");
+        patternsWithBlanks.add(null);
+        patternsWithBlanks.add("");
+        patternsWithBlanks.add("   ");
+
+        userSynchronizationJobUnit.setGroupPrefix(null);
+        userSynchronizationJobUnit.setGroupPrefixes(new GroupPrefixes(Map.of(GroupPrefixes.GROUP_PREFIX_NAME, prefixesWithBlanks)));
+        userSynchronizationJobUnit.setGroupPatterns(new GroupPatterns(Map.of(GroupPatterns.GROUP_PATTERN_NAME, patternsWithBlanks)));
+
+        try (MockedStatic<TransactionalExecutor> mockedExecutor = Mockito.mockStatic(TransactionalExecutor.class);
+             MockedStatic<OSGiUtils> mockedOSGiUtils = Mockito.mockStatic(OSGiUtils.class);
+             MockedStatic<AuthenticationManager> mockedAuthenticationManager = Mockito.mockStatic(AuthenticationManager.class, RETURNS_DEEP_STUBS)
+        ) {
+            mockedExecutor.when(() -> TransactionalExecutor.executeSafelyInReadOnlyTransaction(any(RunnableInReadOnlyTransaction.class)))
+                    .thenAnswer(invocation -> {
+                        RunnableInReadOnlyTransaction<?> transaction = invocation.getArgument(0);
+                        return transaction.run(mock(ReadOnlyTransaction.class));
+                    });
+            mockedExecutor.when(() -> TransactionalExecutor.executeInWriteTransaction(any(RunnableInWriteTransaction.class)))
+                    .thenAnswer(invocation -> {
+                        RunnableInWriteTransaction<?> transaction = invocation.getArgument(0);
+                        return transaction.run(mock(WriteTransaction.class));
+                    });
+            mockedOSGiUtils.when(() -> OSGiUtils.lookupOSGiService(IPolarionServiceFactory.class))
+                    .thenReturn((IPolarionServiceFactory) (s, p, d, ids) -> polarionService);
+            // Connector must be called with the cleaned single-element list, not the original
+            // four-element list with blanks. If cleanup is broken, this stub won't match and
+            // the job log will show getGroups returning an empty result → NotFoundException.
+            when(externalGraphConnector.getGroups(List.of("KEEP_"))).thenReturn(List.of(
+                    new Group("g1", "KEEP_GROUP")
+            ));
+            when(externalGraphConnector.getMembers("g1")).thenReturn(List.of(new Member("u1", "n", "e")));
+            mockedAuthenticationManager.when(() -> AuthenticationManager.getInstance().authenticators())
+                    .thenReturn(List.of(authenticationProviderConfiguration));
+
+            IJobStatus jobStatus = userSynchronizationJobUnit.runInternal(monitor);
+
+            assertThat(jobStatus.getType().getName()).isEqualTo("OK");
+            verify(polarionService).createPolarionUsers(List.of("u1"));
+        }
+    }
+
     private void callRunInternalAndVerifyException(String message) {
         assertThatThrownBy(() -> userSynchronizationJobUnit.runInternal(monitor))
                 .isInstanceOf(NotFoundException.class)

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnitTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnitTest.java
@@ -45,6 +45,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings({"deprecation", "removal"}) // exercises legacy <groupPrefix> path on purpose; drop with the deprecated method
 class UserSynchronizationJobUnitTest {
     @Mock
     private IJobUnitFactory jobUnitFactory;

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnitTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnitTest.java
@@ -6,6 +6,8 @@ import ch.sbb.polarion.extension.aad.synchronizer.connector.GraphFieldOverrides;
 import ch.sbb.polarion.extension.aad.synchronizer.connector.IGraphConnector;
 import ch.sbb.polarion.extension.aad.synchronizer.exception.NotFoundException;
 import ch.sbb.polarion.extension.aad.synchronizer.model.Group;
+import ch.sbb.polarion.extension.aad.synchronizer.model.GroupPatterns;
+import ch.sbb.polarion.extension.aad.synchronizer.model.GroupPrefixes;
 import ch.sbb.polarion.extension.aad.synchronizer.model.Member;
 import ch.sbb.polarion.extension.aad.synchronizer.service.IPolarionServiceFactory;
 import ch.sbb.polarion.extension.aad.synchronizer.service.PolarionService;
@@ -34,6 +36,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -92,7 +95,7 @@ class UserSynchronizationJobUnitTest {
                         return transaction.run(mock(WriteTransaction.class));
                     });
             mockedOSGiUtils.when(() -> OSGiUtils.lookupOSGiService(IPolarionServiceFactory.class)).thenReturn((IPolarionServiceFactory) (polarionSecurityService, polarionProjectService, dryRun, memberIds) -> polarionService);
-            when(externalGraphConnector.getGroups("testPrefix")).thenReturn(List.of(new Group("testGroupId")));
+            when(externalGraphConnector.getGroups(List.of("testPrefix"))).thenReturn(List.of(new Group("testGroupId")));
             when(externalGraphConnector.getMembers("testGroupId")).thenReturn(List.of(new Member("testNickName", "testDisplayName", "testEMail")));
             // Positive request count exercises the summary log branch in runWithGraphConnector.
             // The companion own-connector test leaves the count at Mockito's default 0 to cover
@@ -133,7 +136,7 @@ class UserSynchronizationJobUnitTest {
              MockedConstruction<OAuth2Client> oauth2Mock = Mockito.mockConstruction(OAuth2Client.class, (mock, ctx) ->
                      when(mock.getToken(any(IOAuth2SecurityConfiguration.class))).thenReturn("fake-token"));
              MockedConstruction<GraphConnector> graphMock = Mockito.mockConstruction(GraphConnector.class, (mock, ctx) -> {
-                 when(mock.getGroups("testPrefix")).thenReturn(List.of(new Group("ownGroupId")));
+                 when(mock.getGroups(List.of("testPrefix"))).thenReturn(List.of(new Group("ownGroupId")));
                  when(mock.getMembers("ownGroupId")).thenReturn(List.of(new Member("ownNick", "ownDisplay", "own@example.com")));
              })
         ) {
@@ -189,18 +192,34 @@ class UserSynchronizationJobUnitTest {
     }
 
     @Test
-    void shouldFailWhenNeitherGroupPrefixNorGroupPatternProvided() {
-        // Validation contract: at least one of groupPrefix/groupPattern must be set, otherwise the
-        // job has no way to scope which AAD groups to read and would either fall back to the whole
-        // tenant (when only the prefix branch existed) or do nothing meaningful.
+    void shouldFailWhenNoGroupSelectorProvided() {
+        // Validation contract: at least one of groupPrefix / groupPrefixes / groupPatterns must
+        // be set, otherwise the job has no way to scope which AAD groups to read.
         userSynchronizationJobUnit.setGroupPrefix(null);
-        userSynchronizationJobUnit.setGroupPattern(null);
+        userSynchronizationJobUnit.setGroupPrefixes(null);
+        userSynchronizationJobUnit.setGroupPatterns(null);
 
         try (MockedStatic<AuthenticationManager> mockedAuthenticationManager = Mockito.mockStatic(AuthenticationManager.class, RETURNS_DEEP_STUBS)) {
             mockedAuthenticationManager.when(() -> AuthenticationManager.getInstance().authenticators())
                     .thenReturn(List.of(authenticationProviderConfiguration));
 
-            callRunInternalAndVerifyException("group prefix or group pattern");
+            callRunInternalAndVerifyException("groupPrefix");
+        }
+    }
+
+    @Test
+    void shouldFailWhenLegacyAndPluralPrefixesAreBothSet() {
+        // Mutual exclusion: if a deployer is migrating to <groupPrefixes>, accidentally leaving
+        // the legacy <groupPrefix> in place must surface as a configuration error rather than
+        // silently picking one of the two.
+        userSynchronizationJobUnit.setGroupPrefix("legacyPrefix");
+        userSynchronizationJobUnit.setGroupPrefixes(new GroupPrefixes(Map.of(GroupPrefixes.GROUP_PREFIX_NAME, List.of("A_", "B_"))));
+
+        try (MockedStatic<AuthenticationManager> mockedAuthenticationManager = Mockito.mockStatic(AuthenticationManager.class, RETURNS_DEEP_STUBS)) {
+            mockedAuthenticationManager.when(() -> AuthenticationManager.getInstance().authenticators())
+                    .thenReturn(List.of(authenticationProviderConfiguration));
+
+            callRunInternalAndVerifyException("both <groupPrefix> and <groupPrefixes>");
         }
     }
 
@@ -209,7 +228,7 @@ class UserSynchronizationJobUnitTest {
         // An invalid regex should fail the job at start with a clear configuration error rather
         // than throwing PatternSyntaxException deep inside the run.
         userSynchronizationJobUnit.setGroupPrefix(null);
-        userSynchronizationJobUnit.setGroupPattern("[invalid(");
+        userSynchronizationJobUnit.setGroupPatterns(new GroupPatterns(Map.of(GroupPatterns.GROUP_PATTERN_NAME, "[invalid(")));
 
         try (MockedStatic<AuthenticationManager> mockedAuthenticationManager = Mockito.mockStatic(AuthenticationManager.class, RETURNS_DEEP_STUBS)) {
             mockedAuthenticationManager.when(() -> AuthenticationManager.getInstance().authenticators())
@@ -220,12 +239,33 @@ class UserSynchronizationJobUnitTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
-    void shouldRunWithGroupPatternOnly() {
-        // Pattern-only configuration: no server-side prefix, regex applied client-side.
-        // Verifies the pattern actually filters groups before resolving members.
+    void shouldFailWhenTooManyGroupPrefixes() {
+        // The 15-clause OR limit for Microsoft Graph $filter is enforced at job init so the
+        // operator gets a clear error with the offending count, instead of an opaque HTTP 400 in
+        // the middle of the run.
+        List<String> tooMany = new java.util.ArrayList<>();
+        for (int i = 0; i < 16; i++) {
+            tooMany.add("PREFIX_" + i + "_");
+        }
         userSynchronizationJobUnit.setGroupPrefix(null);
-        userSynchronizationJobUnit.setGroupPattern("^SOME(_OTHER)?_GROUP_PREFIX_.*");
+        userSynchronizationJobUnit.setGroupPrefixes(new GroupPrefixes(Map.of(GroupPrefixes.GROUP_PREFIX_NAME, tooMany)));
+
+        try (MockedStatic<AuthenticationManager> mockedAuthenticationManager = Mockito.mockStatic(AuthenticationManager.class, RETURNS_DEEP_STUBS)) {
+            mockedAuthenticationManager.when(() -> AuthenticationManager.getInstance().authenticators())
+                    .thenReturn(List.of(authenticationProviderConfiguration));
+
+            callRunInternalAndVerifyException("Too many groupPrefixes");
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldRunWithGroupPatternsOnly() {
+        // Pattern-only configuration: no server-side prefix, regex applied client-side. Verifies
+        // the pattern actually filters groups before resolving members and that only patterns
+        // (no prefixes) is a valid configuration.
+        userSynchronizationJobUnit.setGroupPrefix(null);
+        userSynchronizationJobUnit.setGroupPatterns(new GroupPatterns(Map.of(GroupPatterns.GROUP_PATTERN_NAME, "^SOME(_OTHER)?_GROUP_PREFIX_.*")));
 
         try (MockedStatic<TransactionalExecutor> mockedExecutor = Mockito.mockStatic(TransactionalExecutor.class);
              MockedStatic<OSGiUtils> mockedOSGiUtils = Mockito.mockStatic(OSGiUtils.class);
@@ -243,9 +283,9 @@ class UserSynchronizationJobUnitTest {
                     });
             mockedOSGiUtils.when(() -> OSGiUtils.lookupOSGiService(IPolarionServiceFactory.class))
                     .thenReturn((IPolarionServiceFactory) (s, p, d, ids) -> polarionService);
-            // No prefix → connector called with null. Three groups: two should pass the regex,
-            // one (SOME_IGNORED_…) must be filtered out.
-            when(externalGraphConnector.getGroups(null)).thenReturn(List.of(
+            // No prefix → connector called with empty list. Three groups: two should pass the
+            // regex, one (SOME_IGNORED_…) must be filtered out.
+            when(externalGraphConnector.getGroups(List.<String>of())).thenReturn(List.of(
                     new Group("kept1", "SOME_GROUP_PREFIX_X"),
                     new Group("kept2", "SOME_OTHER_GROUP_PREFIX_Y"),
                     new Group("dropped", "SOME_IGNORED_GROUP_PREFIX_Z")
@@ -259,6 +299,47 @@ class UserSynchronizationJobUnitTest {
 
             assertThat(jobStatus.getType().getName()).isEqualTo("OK");
             verify(externalGraphConnector, never()).getMembers("dropped");
+            verify(polarionService).createPolarionUsers(argThat(ids -> ids.size() == 2 && ids.contains("u1") && ids.contains("u2")));
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void shouldRunWithMultipleGroupPrefixes() {
+        // Plural <groupPrefixes>: connector receives the full list and OR-combines server-side.
+        // The legacy singular setter must NOT be set in the same job (mutual exclusion is covered
+        // by a dedicated test above), so reset it here.
+        userSynchronizationJobUnit.setGroupPrefix(null);
+        userSynchronizationJobUnit.setGroupPrefixes(new GroupPrefixes(Map.of(GroupPrefixes.GROUP_PREFIX_NAME, List.of("LEGACY_", "NEW_"))));
+
+        try (MockedStatic<TransactionalExecutor> mockedExecutor = Mockito.mockStatic(TransactionalExecutor.class);
+             MockedStatic<OSGiUtils> mockedOSGiUtils = Mockito.mockStatic(OSGiUtils.class);
+             MockedStatic<AuthenticationManager> mockedAuthenticationManager = Mockito.mockStatic(AuthenticationManager.class, RETURNS_DEEP_STUBS)
+        ) {
+            mockedExecutor.when(() -> TransactionalExecutor.executeSafelyInReadOnlyTransaction(any(RunnableInReadOnlyTransaction.class)))
+                    .thenAnswer(invocation -> {
+                        RunnableInReadOnlyTransaction<?> transaction = invocation.getArgument(0);
+                        return transaction.run(mock(ReadOnlyTransaction.class));
+                    });
+            mockedExecutor.when(() -> TransactionalExecutor.executeInWriteTransaction(any(RunnableInWriteTransaction.class)))
+                    .thenAnswer(invocation -> {
+                        RunnableInWriteTransaction<?> transaction = invocation.getArgument(0);
+                        return transaction.run(mock(WriteTransaction.class));
+                    });
+            mockedOSGiUtils.when(() -> OSGiUtils.lookupOSGiService(IPolarionServiceFactory.class))
+                    .thenReturn((IPolarionServiceFactory) (s, p, d, ids) -> polarionService);
+            when(externalGraphConnector.getGroups(List.of("LEGACY_", "NEW_"))).thenReturn(List.of(
+                    new Group("g1", "LEGACY_TEAM"),
+                    new Group("g2", "NEW_TEAM")
+            ));
+            when(externalGraphConnector.getMembers("g1")).thenReturn(List.of(new Member("u1", "n", "e")));
+            when(externalGraphConnector.getMembers("g2")).thenReturn(List.of(new Member("u2", "n", "e")));
+            mockedAuthenticationManager.when(() -> AuthenticationManager.getInstance().authenticators())
+                    .thenReturn(List.of(authenticationProviderConfiguration));
+
+            IJobStatus jobStatus = userSynchronizationJobUnit.runInternal(monitor);
+
+            assertThat(jobStatus.getType().getName()).isEqualTo("OK");
             verify(polarionService).createPolarionUsers(argThat(ids -> ids.size() == 2 && ids.contains("u1") && ids.contains("u2")));
         }
     }

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
@@ -1,5 +1,6 @@
 package ch.sbb.polarion.extension.aad.synchronizer.connector;
 
+import ch.sbb.polarion.extension.aad.synchronizer.exception.NotFoundException;
 import ch.sbb.polarion.extension.aad.synchronizer.model.Group;
 import ch.sbb.polarion.extension.aad.synchronizer.model.Member;
 import ch.sbb.polarion.extension.aad.synchronizer.service.GraphService;
@@ -16,11 +17,15 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Integration tests that talk to a real Microsoft Entra ID tenant. They are <strong>not</strong>
@@ -334,6 +339,76 @@ class GraphConnectorIT {
                 .isNotEmpty()
                 .doesNotContainNull()
                 .allSatisfy(id -> assertThat(id).isNotBlank());
+    }
+
+    /**
+     * Microsoft Graph must return {@code displayName} on every group hit by {@code /groups?$filter=...}.
+     * The client-side regex filter ({@code groupPattern} job parameter) matches against
+     * this field; if Graph ever returned it null/blank for some group type, regex filtering would
+     * silently drop those groups. The connector-level unit test covers this against a fixture —
+     * here we cross-check it against the live tenant.
+     */
+    @Test
+    void getGroupsPopulatesDisplayName() {
+        List<Group> groups = connector.getGroups(groupPrefix);
+        log("--- getGroups('" + groupPrefix + "') returned " + groups.size() + " group(s) ---");
+        groups.forEach(g -> log("  id=" + g.getId() + " displayName=" + valueOrNullMarker(g.getDisplayName())));
+
+        assertThat(groups).isNotEmpty();
+        assertThat(groups).allSatisfy(g -> {
+            assertThat(g.getDisplayName())
+                    .as("Graph must populate displayName on every returned group — client-side groupPattern relies on it")
+                    .isNotBlank();
+            assertThat(g.getDisplayName())
+                    .as("server-side startswith(displayName, '%s') must hold for every result", groupPrefix)
+                    .startsWith(groupPrefix);
+        });
+    }
+
+    /**
+     * Combined prefix + pattern path: {@code groupPrefix} narrows server-side and a
+     * regex narrows client-side. Constructs a regex from a real {@code displayName} returned by
+     * Graph (escaped via {@code Pattern.quote}) so the test target is the first group exactly,
+     * then asserts that {@link GraphService#getAadMemberIds(String, Pattern)} resolves the same
+     * member id set as a direct {@link GraphConnector#getMembers(String)} call against that one
+     * group.
+     */
+    @Test
+    void getAadMemberIdsCombinesPrefixAndPattern() {
+        List<Group> groups = connector.getGroups(groupPrefix);
+        assertThat(groups).hasSizeGreaterThanOrEqualTo(1);
+        Group target = groups.get(0);
+        Pattern onlyTarget = Pattern.compile("^" + Pattern.quote(target.getDisplayName()) + "$");
+        log("--- combined prefix+pattern: prefix='" + groupPrefix + "' pattern='" + onlyTarget.pattern() + "' ---");
+
+        Set<String> viaService = new GraphService(connector).getAadMemberIds(groupPrefix, onlyTarget);
+        Set<String> direct = connector.getMembers(target.getId()).stream()
+                .map(Member::getId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        log("  via GraphService = " + viaService.size() + " id(s)");
+        log("  direct getMembers = " + direct.size() + " id(s)");
+
+        assertThat(viaService)
+                .as("client-side regex must select exactly the target group — its members equal direct getMembers")
+                .isEqualTo(direct);
+    }
+
+    /**
+     * Empty result after the regex filter must surface as a {@link NotFoundException} rather than
+     * a silent empty member set. A silent empty set would propagate into Polarion as "delete every
+     * user", because {@code deletePolarionUsers} treats the parameter as the keep-list. This is
+     * the unit test covers the same contract on mocks.
+     */
+    @Test
+    void getAadMemberIdsThrowsWhenPatternMatchesNothing() {
+        Pattern impossible = Pattern.compile("^__no_group_should_ever_match_this_sentinel__$");
+        log("--- pattern-matches-nothing: prefix='" + groupPrefix + "' pattern='" + impossible.pattern() + "' ---");
+
+        assertThatThrownBy(() -> new GraphService(connector).getAadMemberIds(groupPrefix, impossible))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("groupPattern");
     }
 
     /**

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
@@ -26,6 +27,7 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Integration tests that talk to a real Microsoft Entra ID tenant. They are <strong>not</strong>
@@ -102,6 +104,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *     <li>{@code expectedUpn} ↔ {@code AAD_SYNC_IT_EXPECTED_UPN} — when set, an additional
  *         assertion verifies that this user is among the resolved members of the first matching
  *         group.</li>
+ *     <li>{@code runFullTenantTest} ↔ {@code AAD_SYNC_IT_RUN_FULL_TENANT_TEST} — opt-in flag for
+ *         the {@code <groupPatterns>}-only path (no server-side prefix). When {@code true},
+ *         {@link #getAadMemberIdsHandlesEmptyPrefixesWithPatternOnly} runs and scans every group
+ *         in the tenant. Off by default to keep the suite cheap on large tenants.</li>
  * </ul>
  *
  * <p>Each test issues real HTTPS calls against {@code login.microsoftonline.com} and
@@ -328,9 +334,9 @@ class GraphConnectorIT {
     void graphServicePipelineDedupesAndFilters() {
         GraphService service = new GraphService(connector);
 
-        Set<String> ids = service.getAadMemberIds(groupPrefix, null);
+        Set<String> ids = service.getAadMemberIds(List.of(groupPrefix), List.of());
 
-        log("--- GraphService.getAadMemberIds('" + groupPrefix + "') ---");
+        log("--- GraphService.getAadMemberIds([" + groupPrefix + "], []) ---");
         log("  resolved " + ids.size() + " unique non-null id(s)");
         ids.forEach(id -> log("  " + id));
 
@@ -343,21 +349,21 @@ class GraphConnectorIT {
 
     /**
      * Microsoft Graph must return {@code displayName} on every group hit by {@code /groups?$filter=...}.
-     * The client-side regex filter ({@code groupPattern} job parameter) matches against
+     * The client-side regex filter ({@code groupPatterns} job parameter) matches against
      * this field; if Graph ever returned it null/blank for some group type, regex filtering would
      * silently drop those groups. The connector-level unit test covers this against a fixture —
      * here we cross-check it against the live tenant.
      */
     @Test
     void getGroupsPopulatesDisplayName() {
-        List<Group> groups = connector.getGroups(groupPrefix);
-        log("--- getGroups('" + groupPrefix + "') returned " + groups.size() + " group(s) ---");
+        List<Group> groups = connector.getGroups(List.of(groupPrefix));
+        log("--- getGroups([" + groupPrefix + "]) returned " + groups.size() + " group(s) ---");
         groups.forEach(g -> log("  id=" + g.getId() + " displayName=" + valueOrNullMarker(g.getDisplayName())));
 
         assertThat(groups).isNotEmpty();
         assertThat(groups).allSatisfy(g -> {
             assertThat(g.getDisplayName())
-                    .as("Graph must populate displayName on every returned group — client-side groupPattern relies on it")
+                    .as("Graph must populate displayName on every returned group — client-side groupPatterns relies on it")
                     .isNotBlank();
             assertThat(g.getDisplayName())
                     .as("server-side startswith(displayName, '%s') must hold for every result", groupPrefix)
@@ -366,22 +372,22 @@ class GraphConnectorIT {
     }
 
     /**
-     * Combined prefix + pattern path: {@code groupPrefix} narrows server-side and a
+     * Combined prefix + pattern path: {@code groupPrefixes} narrows server-side and a
      * regex narrows client-side. Constructs a regex from a real {@code displayName} returned by
      * Graph (escaped via {@code Pattern.quote}) so the test target is the first group exactly,
-     * then asserts that {@link GraphService#getAadMemberIds(String, Pattern)} resolves the same
-     * member id set as a direct {@link GraphConnector#getMembers(String)} call against that one
-     * group.
+     * then asserts that {@link GraphService#getAadMemberIds(java.util.List, java.util.List)}
+     * resolves the same member id set as a direct {@link GraphConnector#getMembers(String)} call
+     * against that one group.
      */
     @Test
     void getAadMemberIdsCombinesPrefixAndPattern() {
-        List<Group> groups = connector.getGroups(groupPrefix);
+        List<Group> groups = connector.getGroups(List.of(groupPrefix));
         assertThat(groups).hasSizeGreaterThanOrEqualTo(1);
         Group target = groups.get(0);
         Pattern onlyTarget = Pattern.compile("^" + Pattern.quote(target.getDisplayName()) + "$");
         log("--- combined prefix+pattern: prefix='" + groupPrefix + "' pattern='" + onlyTarget.pattern() + "' ---");
 
-        Set<String> viaService = new GraphService(connector).getAadMemberIds(groupPrefix, onlyTarget);
+        Set<String> viaService = new GraphService(connector).getAadMemberIds(List.of(groupPrefix), List.of(onlyTarget));
         Set<String> direct = connector.getMembers(target.getId()).stream()
                 .map(Member::getId)
                 .filter(Objects::nonNull)
@@ -398,17 +404,141 @@ class GraphConnectorIT {
     /**
      * Empty result after the regex filter must surface as a {@link NotFoundException} rather than
      * a silent empty member set. A silent empty set would propagate into Polarion as "delete every
-     * user", because {@code deletePolarionUsers} treats the parameter as the keep-list. This is
-     * the unit test covers the same contract on mocks.
+     * user", because {@code deletePolarionUsers} treats the parameter as the keep-list. The unit
+     * test covers the same contract on mocks.
      */
     @Test
     void getAadMemberIdsThrowsWhenPatternMatchesNothing() {
         Pattern impossible = Pattern.compile("^__no_group_should_ever_match_this_sentinel__$");
         log("--- pattern-matches-nothing: prefix='" + groupPrefix + "' pattern='" + impossible.pattern() + "' ---");
 
-        assertThatThrownBy(() -> new GraphService(connector).getAadMemberIds(groupPrefix, impossible))
+        assertThatThrownBy(() -> new GraphService(connector).getAadMemberIds(List.of(groupPrefix), List.of(impossible)))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessageContaining("groupPattern");
+                .hasMessageContaining("groupPatterns");
+    }
+
+    /**
+     * Multiple prefixes must be OR-combined into exactly one Microsoft Graph request — the
+     * defining contract of the new {@code <groupPrefixes>} list parameter. The test splits the
+     * configured single prefix into a strict-prefix + full-prefix pair so the OR'd $filter
+     * resolves to a known superset of the single-prefix result. Verifies both:
+     *
+     * <ul>
+     *     <li>request count delta == 1 (no per-prefix N+1),</li>
+     *     <li>the OR'd response is a superset of the single-prefix response (correct OR
+     *     semantics on Graph's side).</li>
+     * </ul>
+     */
+    @Test
+    void getGroupsBatchesMultiplePrefixesIntoSingleRequest() {
+        assumeTrue(groupPrefix.length() >= 2,
+                "configured groupPrefix '" + groupPrefix + "' is too short to split for this test");
+        String shortPrefix = groupPrefix.substring(0, groupPrefix.length() - 1);
+
+        List<Group> baseline = connector.getGroups(List.of(groupPrefix));
+
+        int before = connector.getRequestCount();
+        List<Group> batched = connector.getGroups(List.of(shortPrefix, groupPrefix));
+        int delta = connector.getRequestCount() - before;
+
+        log("--- batched OR: prefixes=[" + shortPrefix + ", " + groupPrefix + "] ---");
+        log("  baseline groups = " + baseline.size());
+        log("  batched groups  = " + batched.size() + " (calls=" + delta + ")");
+
+        assertThat(delta)
+                .as("OR'd prefixes must use exactly one Graph request, not one per prefix")
+                .isEqualTo(1);
+        assertThat(batched).extracting(Group::getId)
+                .as("OR'd result must be a superset of the strict-prefix result (shortPrefix is a prefix of groupPrefix)")
+                .containsAll(baseline.stream().map(Group::getId).toList());
+    }
+
+    /**
+     * Overlapping prefixes must not produce duplicate {@link Group}s. Microsoft Graph dedupes
+     * naturally on the server side (an entity satisfying {@code A or A} is still returned once),
+     * but this test pins that contract so a future regression — e.g. switching to per-prefix
+     * loop with manual concat — would surface immediately.
+     */
+    @Test
+    void getGroupsDedupesWhenPrefixesOverlap() {
+        List<Group> single = connector.getGroups(List.of(groupPrefix));
+        List<Group> doubled = connector.getGroups(List.of(groupPrefix, groupPrefix));
+
+        log("--- dedup: single=" + single.size() + " doubled=" + doubled.size() + " ---");
+
+        assertThat(doubled).extracting(Group::getId)
+                .as("identical prefix supplied twice must not produce duplicate groups")
+                .doesNotHaveDuplicates()
+                .containsExactlyInAnyOrderElementsOf(single.stream().map(Group::getId).toList());
+    }
+
+    /**
+     * Two patterns OR-combined client-side via {@code anyMatch}. Picks two distinct displayNames
+     * from the live tenant, builds a quoted-literal regex for each, and asserts the resolved
+     * member set equals the union of the two groups' direct member resolutions. Validates the
+     * new {@code <groupPatterns>} list path end-to-end against real Graph responses.
+     */
+    @Test
+    void getAadMemberIdsCombinesMultiplePatternsViaOr() {
+        List<Group> groups = connector.getGroups(List.of(groupPrefix));
+        assumeTrue(groups.size() >= 2,
+                "tenant must expose at least 2 groups under prefix '" + groupPrefix + "' for the multi-pattern test");
+
+        Group a = groups.get(0);
+        Group b = groups.get(1);
+        Pattern pa = Pattern.compile("^" + Pattern.quote(a.getDisplayName()) + "$");
+        Pattern pb = Pattern.compile("^" + Pattern.quote(b.getDisplayName()) + "$");
+        log("--- multi-pattern: a='" + a.getDisplayName() + "' b='" + b.getDisplayName() + "' ---");
+
+        Set<String> viaService = new GraphService(connector)
+                .getAadMemberIds(List.of(groupPrefix), List.of(pa, pb));
+
+        Set<String> directA = connector.getMembers(a.getId()).stream()
+                .map(Member::getId).filter(Objects::nonNull).collect(Collectors.toSet());
+        Set<String> directB = connector.getMembers(b.getId()).stream()
+                .map(Member::getId).filter(Objects::nonNull).collect(Collectors.toSet());
+        Set<String> union = new HashSet<>(directA);
+        union.addAll(directB);
+
+        log("  via GraphService = " + viaService.size() + " id(s)");
+        log("  union (a+b)      = " + union.size() + " id(s)");
+
+        assertThat(viaService)
+                .as("two patterns OR-combined must resolve to the union of the two matched groups' members")
+                .isEqualTo(union);
+    }
+
+    /**
+     * Pattern-only path (empty prefixes): scans every group in the tenant and filters
+     * client-side. Intentionally opt-in via {@code AAD_SYNC_IT_RUN_FULL_TENANT_TEST=true} (or the
+     * properties-file equivalent {@code runFullTenantTest=true}) because the tenant may host
+     * thousands of groups and the {@code /groups} endpoint paginates by 100 — the test would
+     * issue many Graph calls. Default: skipped.
+     *
+     * <p>When enabled, picks one real group via the configured prefix, builds a literal regex
+     * from its displayName, then re-resolves it without any prefix. The resolved member set must
+     * equal the direct {@code getMembers} for that group — proving the no-prefix path actually
+     * iterates through paginated results until it sees the target.</p>
+     */
+    @Test
+    @EnabledIf("runFullTenantTestEnabled")
+    void getAadMemberIdsHandlesEmptyPrefixesWithPatternOnly() {
+        List<Group> reference = connector.getGroups(List.of(groupPrefix));
+        assumeTrue(!reference.isEmpty(),
+                "tenant must expose at least one group under prefix '" + groupPrefix + "'");
+
+        Group target = reference.get(0);
+        Pattern pattern = Pattern.compile("^" + Pattern.quote(target.getDisplayName()) + "$");
+        log("--- pattern-only (whole-tenant scan): target='" + target.getDisplayName() + "' ---");
+
+        Set<String> resolved = new GraphService(connector)
+                .getAadMemberIds(List.of(), List.of(pattern));
+        Set<String> direct = connector.getMembers(target.getId()).stream()
+                .map(Member::getId).filter(Objects::nonNull).collect(Collectors.toSet());
+
+        assertThat(resolved)
+                .as("pattern-only mode must locate the target group when scanning the whole tenant")
+                .isEqualTo(direct);
     }
 
     /**
@@ -534,5 +664,15 @@ class GraphConnectorIT {
                 && lookup("AAD_SYNC_IT_CLIENT_ID", "clientId", null) != null
                 && lookup("AAD_SYNC_IT_CLIENT_SECRET", "clientSecret", null) != null
                 && lookup("AAD_SYNC_IT_GROUP_PREFIX", "groupPrefix", null) != null;
+    }
+
+    /**
+     * Per-method opt-in for tests that scan the whole tenant via the {@code <groupPatterns>}-only
+     * path (no server-side narrowing). Off by default so the suite stays cheap and predictable
+     * on large tenants. Enable with {@code AAD_SYNC_IT_RUN_FULL_TENANT_TEST=true} or the
+     * properties-file equivalent {@code runFullTenantTest=true}.
+     */
+    static boolean runFullTenantTestEnabled() {
+        return "true".equalsIgnoreCase(lookup("AAD_SYNC_IT_RUN_FULL_TENANT_TEST", "runFullTenantTest", "false"));
     }
 }

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
@@ -409,8 +409,10 @@ class GraphConnectorIT {
         Pattern impossible = Pattern.compile("^__no_group_should_ever_match_this_sentinel__$");
         log("--- pattern-matches-nothing: prefix='" + groupPrefix + "' pattern='" + impossible.pattern() + "' ---");
         GraphService service = new GraphService(connector);
+        List<String> prefixes = List.of(groupPrefix);
+        List<Pattern> patterns = List.of(impossible);
 
-        assertThatThrownBy(() -> service.getAadMemberIds(List.of(groupPrefix), List.of(impossible)))
+        assertThatThrownBy(() -> service.getAadMemberIds(prefixes, patterns))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("groupPatterns");
     }

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
@@ -360,15 +360,12 @@ class GraphConnectorIT {
         log("--- getGroups([" + groupPrefix + "]) returned " + groups.size() + " group(s) ---");
         groups.forEach(g -> log("  id=" + g.getId() + " displayName=" + valueOrNullMarker(g.getDisplayName())));
 
-        assertThat(groups).isNotEmpty();
-        assertThat(groups).allSatisfy(g -> {
-            assertThat(g.getDisplayName())
-                    .as("Graph must populate displayName on every returned group — client-side groupPatterns relies on it")
-                    .isNotBlank();
-            assertThat(g.getDisplayName())
-                    .as("server-side startswith(displayName, '%s') must hold for every result", groupPrefix)
-                    .startsWith(groupPrefix);
-        });
+        assertThat(groups)
+                .isNotEmpty()
+                .allSatisfy(g -> assertThat(g.getDisplayName())
+                        .as("Graph must populate displayName on every returned group (used by client-side groupPatterns), and the server-side startswith(displayName, '%s') must hold", groupPrefix)
+                        .isNotBlank()
+                        .startsWith(groupPrefix));
     }
 
     /**
@@ -411,8 +408,9 @@ class GraphConnectorIT {
     void getAadMemberIdsThrowsWhenPatternMatchesNothing() {
         Pattern impossible = Pattern.compile("^__no_group_should_ever_match_this_sentinel__$");
         log("--- pattern-matches-nothing: prefix='" + groupPrefix + "' pattern='" + impossible.pattern() + "' ---");
+        GraphService service = new GraphService(connector);
 
-        assertThatThrownBy(() -> new GraphService(connector).getAadMemberIds(List.of(groupPrefix), List.of(impossible)))
+        assertThatThrownBy(() -> service.getAadMemberIds(List.of(groupPrefix), List.of(impossible)))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("groupPatterns");
     }

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
@@ -385,17 +385,52 @@ class GraphConnectorTest {
 
     @Test
     void getGroupsOmitsServerSideFilterWhenPrefixIsBlank(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
-        // When only groupPattern is configured (and groupPrefix is blank/null), the connector
-        // must fetch all groups: no $filter query parameter on the Graph request. The job then
-        // narrows the result client-side. Verifying via WireMock that the request URL does not
-        // carry a $filter would be ideal, but for our purposes confirming that null and blank
-        // both succeed (no NPE building the OData filter) is enough.
+        // When only groupPatterns is configured (and no prefixes), the connector must fetch all
+        // groups: no $filter query parameter on the Graph request. The job then narrows the
+        // result client-side. Verifying via WireMock that the request URL does not carry a
+        // $filter would be ideal, but for our purposes confirming that null/blank/empty-list
+        // shapes all succeed (no NPE building the OData filter) is enough.
         mockGetGroupsCall("groups.json", 200);
         GraphConnector connector = createConnector(wmRuntimeInfo);
 
-        assertThat(connector.getGroups(null)).hasSize(5);
+        assertThat(connector.getGroups((String) null)).hasSize(5);
         assertThat(connector.getGroups("")).hasSize(5);
         assertThat(connector.getGroups("   ")).hasSize(5);
+        assertThat(connector.getGroups(List.<String>of())).hasSize(5);
+        assertThat(connector.getGroups((List<String>) null)).hasSize(5);
+    }
+
+    @Test
+    void getGroupsOrCombinesMultiplePrefixesIntoSingleFilter(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
+        // Plural <groupPrefixes> path: the connector must build a single Graph request with
+        // startswith(displayName, 'A_') or startswith(displayName, 'B_'). One request, not two.
+        mockGetGroupsCall("groups.json", 200);
+        GraphConnector connector = createConnector(wmRuntimeInfo);
+
+        int before = connector.getRequestCount();
+        List<Group> result = connector.getGroups(List.of("LEGACY_", "NEW_"));
+        int delta = connector.getRequestCount() - before;
+
+        assertThat(result).hasSize(5);
+        assertThat(delta)
+                .as("multiple prefixes must be OR-combined into a single Graph request")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void getGroupsRejectsTooManyPrefixes(WireMockRuntimeInfo wmRuntimeInfo) {
+        // Cap is enforced before sending the request: more than MAX_OR_GROUP_PREFIXES would let
+        // Graph reject the request with HTTP 400 (opaque to the operator). The connector must
+        // surface a clear configuration error instead.
+        GraphConnector connector = createConnector(wmRuntimeInfo);
+        List<String> tooMany = new ArrayList<>();
+        for (int i = 0; i < GraphConnector.MAX_OR_GROUP_PREFIXES + 1; i++) {
+            tooMany.add("PREFIX_" + i + "_");
+        }
+
+        assertThatThrownBy(() -> connector.getGroups(tooMany))
+                .isInstanceOf(InvalidGraphResponseException.class)
+                .hasMessageContaining("Too many groupPrefixes");
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/IGraphConnectorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/IGraphConnectorTest.java
@@ -5,7 +5,10 @@ import ch.sbb.polarion.extension.aad.synchronizer.model.Member;
 import ch.sbb.polarion.extension.aad.synchronizer.model.OrganizationData;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -16,10 +19,41 @@ class IGraphConnectorTest {
         // External IGraphConnector implementations registered via OSGi are not required to
         // implement the request-count API. The interface provides a default of 0 which the job
         // logger treats as "unavailable" (suppresses the summary line).
+        IGraphConnector connector = newSingularOnlyConnector(Map.of());
+
+        assertThat(connector.getRequestCount()).isZero();
+    }
+
+    @Test
+    void defaultGetGroupsListLoopsOverSingularAndDedupes() {
+        // External IGraphConnector implementations may only override getGroups(String). The
+        // default getGroups(List<String>) implementation must call getGroups(String) per prefix
+        // and dedup by id so the same group appearing under two overlapping prefixes is
+        // returned once. This exercises the OSGi backwards-compat path that the GraphConnector
+        // override would normally bypass.
+        Map<String, List<Group>> singular = new HashMap<>();
+        singular.put("A_", List.of(new Group("g1"), new Group("shared")));
+        singular.put("B_", List.of(new Group("g2"), new Group("shared")));
+        IGraphConnector connector = newSingularOnlyConnector(singular);
+
+        List<Group> result = connector.getGroups(List.of("A_", "B_"));
+
+        assertThat(result).extracting(Group::getId)
+                .as("default impl must dedup by group id when prefixes return overlapping sets")
+                .containsExactly("g1", "shared", "g2");
+    }
+
+    @Test
+    void defaultGetGroupsListDelegatesToSingularNullForEmptyList() {
+        // Empty list and null list both mean "fetch all groups" in the contract. The default
+        // impl must translate them to getGroups((String) null) so external implementations only
+        // need to handle one shape.
+        List<String> calls = new ArrayList<>();
         IGraphConnector connector = new IGraphConnector() {
             @Override
             public List<Group> getGroups(String groupPrefix) {
-                return List.of();
+                calls.add(String.valueOf(groupPrefix));
+                return List.of(new Group("all"));
             }
 
             @Override
@@ -33,6 +67,27 @@ class IGraphConnectorTest {
             }
         };
 
-        assertThat(connector.getRequestCount()).isZero();
+        assertThat(connector.getGroups(List.<String>of())).extracting(Group::getId).containsExactly("all");
+        assertThat(connector.getGroups((List<String>) null)).extracting(Group::getId).containsExactly("all");
+        assertThat(calls).containsExactly("null", "null");
+    }
+
+    private static IGraphConnector newSingularOnlyConnector(Map<String, List<Group>> singularReturns) {
+        return new IGraphConnector() {
+            @Override
+            public List<Group> getGroups(String groupPrefix) {
+                return singularReturns.getOrDefault(groupPrefix, List.of());
+            }
+
+            @Override
+            public List<Member> getMembers(String key) {
+                return List.of();
+            }
+
+            @Override
+            public OrganizationData getOrganizationData() {
+                return null;
+            }
+        };
     }
 }

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPatternsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPatternsTest.java
@@ -1,0 +1,48 @@
+package ch.sbb.polarion.extension.aad.synchronizer.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers every shape Polarion can deliver to the {@code <groupPatterns>} parameter constructor.
+ * Mirrors {@link GroupPrefixesTest} — the two wrappers share the same conversion logic and
+ * differ only in the inner element name, so any divergence between them is suspicious and
+ * must surface in this test pair.
+ */
+class GroupPatternsTest {
+
+    @Test
+    void nullMapYieldsEmptyList() {
+        assertThat(new GroupPatterns(null).getPatterns()).isEmpty();
+    }
+
+    @Test
+    void missingKeyYieldsEmptyList() {
+        assertThat(new GroupPatterns(Map.of("unrelated", "value")).getPatterns()).isEmpty();
+    }
+
+    @Test
+    void singleStringChildYieldsSingletonList() {
+        GroupPatterns patterns = new GroupPatterns(Map.of(
+                GroupPatterns.GROUP_PATTERN_NAME, "^FOO_.*"));
+
+        assertThat(patterns.getPatterns()).containsExactly("^FOO_.*");
+    }
+
+    @Test
+    void multipleChildrenYieldList() {
+        GroupPatterns patterns = new GroupPatterns(Map.of(
+                GroupPatterns.GROUP_PATTERN_NAME, List.of("^A_.*", "^B_.*")));
+
+        assertThat(patterns.getPatterns()).containsExactly("^A_.*", "^B_.*");
+    }
+
+    @Test
+    void unexpectedValueTypeYieldsEmptyList() {
+        assertThat(new GroupPatterns(Map.of(GroupPatterns.GROUP_PATTERN_NAME, 42)).getPatterns()).isEmpty();
+    }
+}

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPrefixesTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPrefixesTest.java
@@ -1,0 +1,53 @@
+package ch.sbb.polarion.extension.aad.synchronizer.model;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers every shape Polarion can deliver to the {@code <groupPrefixes>} parameter constructor:
+ * {@code null} map, missing key, single-child case (Polarion delivers the inner element as a
+ * bare {@link String} when only one is present), multi-child case (delivered as a {@link List}),
+ * and the wrong-type fallback that protects against future changes in Polarion's parameter
+ * marshalling.
+ */
+class GroupPrefixesTest {
+
+    @Test
+    void nullMapYieldsEmptyList() {
+        assertThat(new GroupPrefixes(null).getPrefixes()).isEmpty();
+    }
+
+    @Test
+    void missingKeyYieldsEmptyList() {
+        assertThat(new GroupPrefixes(Map.of("unrelated", "value")).getPrefixes()).isEmpty();
+    }
+
+    @Test
+    void singleStringChildYieldsSingletonList() {
+        // Polarion collapses <groupPrefixes><groupPrefix>X</groupPrefix></groupPrefixes>
+        // to a bare String under the inner element name — wrapper must promote it to a list.
+        GroupPrefixes prefixes = new GroupPrefixes(Map.of(GroupPrefixes.GROUP_PREFIX_NAME, "ONE_"));
+
+        assertThat(prefixes.getPrefixes()).containsExactly("ONE_");
+    }
+
+    @Test
+    void multipleChildrenYieldList() {
+        GroupPrefixes prefixes = new GroupPrefixes(Map.of(
+                GroupPrefixes.GROUP_PREFIX_NAME, List.of("LEGACY_", "NEW_")));
+
+        assertThat(prefixes.getPrefixes()).containsExactly("LEGACY_", "NEW_");
+    }
+
+    @Test
+    void unexpectedValueTypeYieldsEmptyList() {
+        // Defensive: if a future Polarion release ever delivers a Map or Number under the inner
+        // element key (not currently possible, but the type signature allows it), the wrapper
+        // must not throw — empty list keeps the job init's mutual-exclusion logic well-defined.
+        assertThat(new GroupPrefixes(Map.of(GroupPrefixes.GROUP_PREFIX_NAME, 42)).getPrefixes()).isEmpty();
+    }
+}

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/service/GraphServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/service/GraphServiceTest.java
@@ -25,7 +25,6 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
@@ -65,36 +64,59 @@ class GraphServiceTest {
     void testGetAadMemberIds(List<Group> groups, Map<String, List<Member>> membersInGroupMap, List<String> expected) {
 
         GraphService service = new GraphService(graphConnector);
-        String groupPrefix = anyString();
-        when(graphConnector.getGroups(groupPrefix)).thenReturn(groups);
+        List<String> prefixes = List.of("SOME_");
+        when(graphConnector.getGroups(prefixes)).thenReturn(groups);
         membersInGroupMap.forEach((groupId, members) ->
                 when(graphConnector.getMembers(groupId)).thenReturn(members)
         );
 
-        List<String> members = new ArrayList<>(service.getAadMemberIds(groupPrefix, null));
+        List<String> members = new ArrayList<>(service.getAadMemberIds(prefixes, List.of()));
 
         assertThat(members).hasSize(expected.size()).isEqualTo(expected);
     }
 
     @Test
-    void testGetAadMemberIdsAppliesGroupPattern() {
-        // groupPattern narrows the server-side result client-side: only groups whose displayName
-        // fully matches the regex contribute their members. Example: match SOME_ and SOME_OTHER_
+    void testGetAadMemberIdsAppliesGroupPatterns() {
+        // groupPatterns narrow the server-side result client-side: a group passes when ANY of the
+        // configured patterns matches its displayName fully. Example: match SOME_ and SOME_OTHER_
         // prefixes while excluding SOME_IGNORED_.
         Group keep1 = new Group("g1", "SOME_GROUP_PREFIX_A");
         Group keep2 = new Group("g2", "SOME_OTHER_GROUP_PREFIX_B");
         Group drop = new Group("g3", "SOME_IGNORED_GROUP_PREFIX_C");
 
-        when(graphConnector.getGroups("SOME")).thenReturn(List.of(keep1, keep2, drop));
+        List<String> prefixes = List.of("SOME");
+        when(graphConnector.getGroups(prefixes)).thenReturn(List.of(keep1, keep2, drop));
         when(graphConnector.getMembers("g1")).thenReturn(List.of(new Member("m1", "n", "e")));
         when(graphConnector.getMembers("g2")).thenReturn(List.of(new Member("m2", "n", "e")));
 
         Pattern pattern = Pattern.compile("^SOME(_OTHER)?_GROUP_PREFIX_.*");
         GraphService service = new GraphService(graphConnector);
 
-        List<String> members = new ArrayList<>(service.getAadMemberIds("SOME", pattern));
+        List<String> members = new ArrayList<>(service.getAadMemberIds(prefixes, List.of(pattern)));
 
         assertThat(members).containsExactlyInAnyOrder("m1", "m2");
+    }
+
+    @Test
+    void testGetAadMemberIdsCombinesMultiplePatternsWithOr() {
+        // Multiple patterns are OR-combined: a group is kept if ANY pattern matches. Verifies the
+        // anyMatch wiring so two disjoint regexes can be supplied without fusing them into one
+        // alternation manually.
+        Group a = new Group("g1", "ALPHA_TEAM");
+        Group b = new Group("g2", "BETA_TEAM");
+        Group c = new Group("g3", "GAMMA_TEAM");
+
+        List<String> prefixes = List.of();
+        when(graphConnector.getGroups(prefixes)).thenReturn(List.of(a, b, c));
+        when(graphConnector.getMembers("g1")).thenReturn(List.of(new Member("ma", "n", "e")));
+        when(graphConnector.getMembers("g2")).thenReturn(List.of(new Member("mb", "n", "e")));
+
+        List<Pattern> patterns = List.of(Pattern.compile("^ALPHA_.*"), Pattern.compile("^BETA_.*"));
+        GraphService service = new GraphService(graphConnector);
+
+        List<String> members = new ArrayList<>(service.getAadMemberIds(prefixes, patterns));
+
+        assertThat(members).containsExactlyInAnyOrder("ma", "mb");
     }
 
     @Test
@@ -102,14 +124,15 @@ class GraphServiceTest {
         // If the regex filters out every group the connector returned, the job must fail loudly
         // instead of silently producing an empty member set (which would later wipe Polarion).
         Group g = new Group("g1", "SOME_IGNORED_GROUP_PREFIX_A");
-        when(graphConnector.getGroups("SOME")).thenReturn(List.of(g));
+        List<String> prefixes = List.of("SOME");
+        when(graphConnector.getGroups(prefixes)).thenReturn(List.of(g));
 
         Pattern pattern = Pattern.compile("^SOME(_OTHER)?_GROUP_PREFIX_.*");
         GraphService service = new GraphService(graphConnector);
 
-        assertThatThrownBy(() -> service.getAadMemberIds("SOME", pattern))
+        assertThatThrownBy(() -> service.getAadMemberIds(prefixes, List.of(pattern)))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessageContaining("groupPattern");
+                .hasMessageContaining("groupPatterns");
     }
 
     @Test
@@ -118,13 +141,14 @@ class GraphServiceTest {
         // not populating it) must not blow up — it just doesn't match any pattern.
         Group named = new Group("g1", "SOME_GROUP_PREFIX_A");
         Group unnamed = new Group("g2");
-        when(graphConnector.getGroups("SOME")).thenReturn(List.of(named, unnamed));
+        List<String> prefixes = List.of("SOME");
+        when(graphConnector.getGroups(prefixes)).thenReturn(List.of(named, unnamed));
         when(graphConnector.getMembers("g1")).thenReturn(List.of(new Member("m1", "n", "e")));
 
         Pattern pattern = Pattern.compile("^SOME_GROUP_PREFIX_.*");
         GraphService service = new GraphService(graphConnector);
 
-        List<String> members = new ArrayList<>(service.getAadMemberIds("SOME", pattern));
+        List<String> members = new ArrayList<>(service.getAadMemberIds(prefixes, List.of(pattern)));
 
         assertThat(members).containsExactly("m1");
     }

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/service/GraphServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/service/GraphServiceTest.java
@@ -79,8 +79,8 @@ class GraphServiceTest {
     @Test
     void testGetAadMemberIdsAppliesGroupPattern() {
         // groupPattern narrows the server-side result client-side: only groups whose displayName
-        // fully matches the regex contribute their members. The example mirrors the issue #81
-        // motivating example: match SOME_ and SOME_OTHER_ prefixes while excluding SOME_IGNORED_.
+        // fully matches the regex contribute their members. Example: match SOME_ and SOME_OTHER_
+        // prefixes while excluding SOME_IGNORED_.
         Group keep1 = new Group("g1", "SOME_GROUP_PREFIX_A");
         Group keep2 = new Group("g2", "SOME_OTHER_GROUP_PREFIX_B");
         Group drop = new Group("g3", "SOME_IGNORED_GROUP_PREFIX_C");

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/service/GraphServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/service/GraphServiceTest.java
@@ -127,10 +127,10 @@ class GraphServiceTest {
         List<String> prefixes = List.of("SOME");
         when(graphConnector.getGroups(prefixes)).thenReturn(List.of(g));
 
-        Pattern pattern = Pattern.compile("^SOME(_OTHER)?_GROUP_PREFIX_.*");
+        List<Pattern> patterns = List.of(Pattern.compile("^SOME(_OTHER)?_GROUP_PREFIX_.*"));
         GraphService service = new GraphService(graphConnector);
 
-        assertThatThrownBy(() -> service.getAadMemberIds(prefixes, List.of(pattern)))
+        assertThatThrownBy(() -> service.getAadMemberIds(prefixes, patterns))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("groupPatterns");
     }


### PR DESCRIPTION
### Proposed changes

This pull request introduces a major overhaul to how Azure AD group filtering is configured and processed for synchronization jobs. The changes deprecate the old single-prefix and single-pattern configuration in favor of new pluralized, list-based XML elements for both prefixes and patterns, allowing for more flexible and robust filtering. The implementation is updated throughout the codebase to support these new structures, enforce mutual exclusivity, and provide clear error handling and migration guidance.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
