### PR TITLE
feat: change group config to union semantics and compact Graph log

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ To run this job on a schedule, configure it in the global `Administration` / `Sc
     -->
 
     <!-- Optional: regex list applied client-side against AAD group displayName (full match).
-         A group is included when ANY pattern matches. Combined with groupPrefixes the prefixes
-         narrow the result server-side and the patterns narrow further client-side. -->
+         A group is included when ANY pattern matches. Combined with groupPrefixes the two
+         selectors are unioned (independent OR-sources) — prefixes fetch a server-filtered set,
+         patterns fetch the full tenant + filter client-side, results are deduped by group id. -->
     <!--
     <groupPatterns>
         <groupPattern>^SOME(_OTHER)?_GROUP_PREFIX_.*</groupPattern>
@@ -102,6 +103,12 @@ To run this job on a schedule, configure it in the global `Administration` / `Sc
 
     <dryRun>true</dryRun>
     <checkLastSynchronization>false</checkLastSynchronization>
+
+    <!-- Optional: dumps every Graph response as full pretty-printed JSON instead of the default
+         compact one-line-per-entity summary. Use only for one-off diagnostics. -->
+    <!--
+    <verboseGraphLog>true</verboseGraphLog>
+    -->
 </job>
 ```
 
@@ -227,11 +234,11 @@ extension owned by an AAD application with id `abc123de-f456-7890-abcd-ef1234567
   share two or more disjoint naming conventions (e.g. `LEGACY_` and `NEW_`).
 - **Group Patterns** (`groupPatterns`): Optional list of regular expressions
   ([`java.util.regex`](https://docs.oracle.com/javase/tutorial/essential/regex/) syntax,
-  full match like `String.matches`) applied client-side against `displayName`. A group is
-  included when **any** pattern matches. Useful for excluding specific prefixes, e.g.
-  `^SOME(_OTHER)?_GROUP_PREFIX_.*` matches `SOME_GROUP_PREFIX_*` and
-  `SOME_OTHER_GROUP_PREFIX_*` while skipping `SOME_IGNORED_GROUP_PREFIX_*`. Invalid regex
-  fails the job at start with a clear error and the offending pattern.
+  full match like `String.matches`) applied client-side against `displayName` after fetching
+  every group in the tenant. A group is included when **any** pattern matches. Useful when the
+  desired groups don't share a common literal prefix, e.g. `^(LEGACY|NEW)_TEAM_.*` matches
+  both naming conventions in a single selector. Invalid regex fails the job at start with a
+  clear error and the offending pattern.
 
 > [!WARNING]
 > The legacy single-prefix form `<groupPrefix>SOME_</groupPrefix>` is **deprecated** and
@@ -245,11 +252,19 @@ extension owned by an AAD application with id `abc123de-f456-7890-abcd-ef1234567
 > The two forms are mutually exclusive — set one or the other, not both. When the legacy
 > form is used, the job logs a deprecation warning at every run.
 
-At least one of `groupPrefix`, `groupPrefixes`, or `groupPatterns` must be provided. When
-prefixes and patterns are both set, prefixes narrow the result server-side and patterns
-narrow it further on the extension side. When only `groupPatterns` is set, all groups in
-the tenant are fetched and filtered client-side — prefer to also set `groupPrefixes` on
-large tenants to keep the Graph response size bounded.
+At least one of `groupPrefix`, `groupPrefixes`, or `groupPatterns` must be provided. The two
+selectors are independent OR-sources and produce a **union** of groups:
+
+- `groupPrefixes` only — one Graph request with a server-side `startswith($filter)`.
+- `groupPatterns` only — one unfiltered Graph request, regex applied client-side.
+- both — both requests are issued and the resulting groups are unioned by id, deduped, and
+  member resolution runs once per group. Useful when an operator wants a broad family of
+  groups by prefix **plus** outliers captured only by a regex (e.g. prefix `TEAM_` plus pattern
+  `^ADMIN_SPECIAL$`).
+
+When only `groupPatterns` is set, all groups in the tenant are fetched and filtered
+client-side — prefer to also set `groupPrefixes` on large tenants to keep at least one of the
+two Graph responses bounded.
 
 #### User Filters
 
@@ -273,6 +288,12 @@ If both `filter` and `accounts` are provided, the users that match the filter or
 
 - **Dry Run** (`dryRun`): Enables simulation mode, where no actual changes are made.
 - **Check Last Synchronization** (`checkLastSynchronization`): Determines whether to verify the timestamp of the last synchronization before execution.
+- **Verbose Graph Log** (`verboseGraphLog`): Optional. Default `false`. When `false`, every Microsoft
+  Graph response is rendered as a one-line-per-entity compact summary (id + displayName + mail +
+  employeeId when present, capped at 20 entries with a `+N more` suffix). Set to `true` to fall
+  back to the legacy behavior — full pretty-printed JSON dump of every response. Use only for
+  one-off diagnostics; production runs on tenants with many groups should leave this at `false`
+  to keep the job log readable.
 
 ### REST API
 

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnit.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnit.java
@@ -37,4 +37,6 @@ public interface AADUserSynchronizationJobUnit extends IJobUnit {
     void setDryRun(Boolean dryRun);
 
     void setCheckLastSynchronization(Boolean checkLastSynchronization);
+
+    void setVerboseGraphLog(Boolean verboseGraphLog);
 }

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactory.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactory.java
@@ -81,7 +81,7 @@ public class AADUserSynchronizationJobUnitFactory implements IJobUnitFactory {
                 ) {
                     @Override
                     public Object convertValue(Object value) {
-                        return value instanceof Map<?, ?> map ? new GroupPrefixes(map) : null;
+                        return GroupPrefixes.fromRawValue(value);
                     }
                 }.setRequired(false)
         );
@@ -95,7 +95,7 @@ public class AADUserSynchronizationJobUnitFactory implements IJobUnitFactory {
                 ) {
                     @Override
                     public Object convertValue(Object value) {
-                        return value instanceof Map<?, ?> map ? new GroupPatterns(map) : null;
+                        return GroupPatterns.fromRawValue(value);
                     }
                 }.setRequired(false)
         );

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactory.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactory.java
@@ -26,6 +26,7 @@ public class AADUserSynchronizationJobUnitFactory implements IJobUnitFactory {
     public static final String BLACKLIST = "blacklist";
     public static final String DRY_RUN = "dryRun";
     public static final String CHECK_LAST_SYNCHRONIZATION = "checkLastSynchronization";
+    public static final String VERBOSE_GRAPH_LOG = "verboseGraphLog";
 
     @Override
     public IJobUnit createJobUnit(String name) {
@@ -90,7 +91,7 @@ public class AADUserSynchronizationJobUnitFactory implements IJobUnitFactory {
                 new SimpleJobParameter(
                         desc.getRootParameterGroup(),
                         GROUP_PATTERNS,
-                        "List of regular expressions matched client-side against the AAD group displayName (full match, java.util.regex). XML: <groupPatterns><groupPattern>...</groupPattern>...</groupPatterns>. A group is included if any pattern matches. Use to match disjoint prefixes or exclude specific ones, e.g. ^SOME(_OTHER)?_GROUP_PREFIX_.* . Combined with groupPrefix(es) the prefixes narrow server-side and the patterns narrow further client-side. At least one of groupPrefix/groupPrefixes/groupPatterns must be provided.",
+                        "List of regular expressions matched client-side against the AAD group displayName (full match, java.util.regex). XML: <groupPatterns><groupPattern>...</groupPattern>...</groupPatterns>. A group is included if any pattern matches. Use to match disjoint naming conventions in a single selector, e.g. ^(LEGACY|NEW)_TEAM_.* . Combined with groupPrefix(es) the two selectors act as independent OR-sources: prefixes fetch a server-filtered set, patterns fetch the full tenant + filter client-side, results are unioned by group id. At least one of groupPrefix/groupPrefixes/groupPatterns must be provided.",
                         new JobParameterPrimitiveType("GroupPatterns", GroupPatterns.class)
                 ) {
                     @Override
@@ -143,6 +144,12 @@ public class AADUserSynchronizationJobUnitFactory implements IJobUnitFactory {
                 desc.getRootParameterGroup(),
                 CHECK_LAST_SYNCHRONIZATION,
                 "Enable/disable checking for the last AAD synchronization",
+                booleanType).setRequired(false));
+
+        desc.addParameter(new SimpleJobParameter(
+                desc.getRootParameterGroup(),
+                VERBOSE_GRAPH_LOG,
+                "When true, every Microsoft Graph response is dumped to the job log as pretty-printed JSON (legacy behavior). Default false: log a one-line-per-entity compact summary (id, displayName, mail, employeeId when present), capped at 20 entries with a +N-more suffix. Use true for one-off diagnostics; production runs on tenants with many groups should leave this at false to keep the job log readable.",
                 booleanType).setRequired(false));
 
         return desc;

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnit.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnit.java
@@ -56,6 +56,7 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
     private Blacklist blacklist;
     private boolean dryRun = false;
     private boolean checkLastSynchronization = false;
+    private boolean verboseGraphLog = false;
 
     public UserSynchronizationJobUnit(String name, IJobUnitFactory creator) {
         super(name, creator);
@@ -98,6 +99,9 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
 
         String graphApiToken = new OAuth2Client().getToken(authenticationProviderConfiguration);
         try (GraphConnector ownGraphConnector = new GraphConnector(authenticationProviderConfiguration, graphApiToken, buildGraphFieldOverrides())) {
+            // verboseGraphLog is implementation-specific to our bundled connector — external
+            // IGraphConnector implementations (OSGi-registered) handle their own logging.
+            ownGraphConnector.setVerboseLog(verboseGraphLog);
             return runWithGraphConnector(ownGraphConnector);
         }
     }
@@ -317,6 +321,11 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
     @Override
     public void setCheckLastSynchronization(Boolean checkLastSynchronization) {
         this.checkLastSynchronization = checkLastSynchronization;
+    }
+
+    @Override
+    public void setVerboseGraphLog(Boolean verboseGraphLog) {
+        this.verboseGraphLog = Boolean.TRUE.equals(verboseGraphLog);
     }
 
 }

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
@@ -495,7 +495,8 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
         return responseContent;
     }
 
-    private static String formatVerbose(String responseContent) {
+    @VisibleForTesting
+    static String formatVerbose(String responseContent) {
         try {
             return System.lineSeparator() + new JSONObject(responseContent).toString(JSON_INDENT_FACTOR);
         } catch (JSONException e) {

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
@@ -30,6 +30,7 @@ import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 public class GraphConnector implements IGraphConnector, AutoCloseable {
@@ -421,7 +422,7 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
 
     @SuppressWarnings("unchecked")
     private <T> T parseSuccessfulResponse(Response response, Class<T> targetClass) {
-        String responseContent = getResponseContent(response);
+        String responseContent = Objects.requireNonNullElse(getResponseContent(response), "");
         if (targetClass == String.class) {
             return (T) responseContent;
         }
@@ -559,21 +560,25 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
         }
         StringBuilder out = new StringBuilder();
         for (String field : SUMMARY_FIELDS) {
-            if (!obj.has(field) || obj.isNull(field)) {
-                continue;
-            }
-            String rendered = String.valueOf(obj.opt(field));
-            if (rendered.isEmpty()) {
-                continue;
-            }
-            if (out.length() > 0) {
-                out.append(' ');
-            }
-            out.append(field).append("=\"").append(rendered).append('"');
+            appendIfPresent(out, obj, field);
         }
         // No known field present (atypical for Graph entities, but possible for opaque types):
         // fall back to the inline JSON so the operator still sees what came back.
-        return out.length() == 0 ? obj.toString() : out.toString();
+        return out.isEmpty() ? obj.toString() : out.toString();
+    }
+
+    private static void appendIfPresent(StringBuilder out, JSONObject obj, String field) {
+        if (!obj.has(field) || obj.isNull(field)) {
+            return;
+        }
+        String rendered = String.valueOf(obj.opt(field));
+        if (rendered.isEmpty()) {
+            return;
+        }
+        if (!out.isEmpty()) {
+            out.append(' ');
+        }
+        out.append(field).append("=\"").append(rendered).append('"');
     }
 
     private static String truncate(String s, int maxLen) {

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnector.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.polarion.core.config.IOAuth2SecurityConfiguration;
 import org.jetbrains.annotations.VisibleForTesting;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -38,6 +39,28 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
     private static final int JSON_INDENT_FACTOR = 4;
     private static final String GRAPH_MICROSOFT_URL = "https://graph.microsoft.com";
     private static final String SELECT_QUERY_PARAM = "$select";
+
+    /**
+     * Maximum number of entities sampled in the compact response summary. Larger lists are
+     * truncated with a "+N more" suffix pointing at the {@code verboseGraphLog} job parameter.
+     * Trade-off: too small and an operator can't spot which groups came back; too large and the
+     * compact summary defeats its own purpose on tenants with hundreds of groups.
+     */
+    private static final int MAX_SUMMARY_ENTRIES = 20;
+    /**
+     * Cap on the raw response content emitted when the body fails to parse as JSON. Keeps a
+     * malformed/oversized payload from blowing up the job log while still leaving enough head
+     * for diagnostics.
+     */
+    private static final int MAX_RAW_FALLBACK_CHARS = 2_000;
+    /**
+     * Field names rendered into the compact entity summary, in display order. Chosen to match
+     * the projections the synchronizer requests from Graph (groups carry {@code displayName},
+     * users carry the configured id/name/email mapping). Anything not in this list is dropped
+     * from the summary; toggle {@code verboseGraphLog} to see the full payload.
+     */
+    private static final List<String> SUMMARY_FIELDS = List.of(
+            "id", "displayName", "userPrincipalName", "mail", "employeeId", "mailNickname");
 
     /**
      * Maximum number of times a single Microsoft Graph request will be retried after receiving a
@@ -73,6 +96,13 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
      * underlying connection pool is released by {@link #close()} at the end of the job.
      */
     private final Client httpClient;
+    /**
+     * When true, every Graph response body is dumped to the job log as pretty-printed JSON
+     * (legacy behavior). When false (the default), the connector emits a one-line-per-entity
+     * compact summary capped at {@link #MAX_SUMMARY_ENTRIES}. Toggled per-run via the
+     * {@code verboseGraphLog} job parameter.
+     */
+    private boolean verboseLog;
 
     public GraphConnector(IOAuth2SecurityConfiguration authenticationProviderConfiguration, String token) {
         this(authenticationProviderConfiguration, token, null, GRAPH_MICROSOFT_URL);
@@ -92,6 +122,15 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
         this.urlBuilder = new UrlBuilder();
         this.graphUrl = graphUrl;
         this.httpClient = ClientBuilder.newClient();
+    }
+
+    /**
+     * Toggles between full pretty-printed JSON dumps (legacy, useful for diagnostics on small
+     * tenants) and the compact entity-summary log (default, scales to hundreds of groups). The
+     * job parameter {@code verboseGraphLog} flows here from {@code UserSynchronizationJobUnit}.
+     */
+    public void setVerboseLog(boolean verboseLog) {
+        this.verboseLog = verboseLog;
     }
 
     @Override
@@ -448,16 +487,101 @@ public class GraphConnector implements IGraphConnector, AutoCloseable {
         }
     }
 
-    private static String getResponseContent(Response response) {
+    private String getResponseContent(Response response) {
         String responseContent = response.readEntity(String.class);
-        String jsonContent = null;
+        JobLogger.getInstance().log("Response content: %s",
+                verboseLog ? formatVerbose(responseContent) : summarizeJsonResponse(responseContent));
+        return responseContent;
+    }
+
+    private static String formatVerbose(String responseContent) {
         try {
-            jsonContent = new JSONObject(responseContent).toString(JSON_INDENT_FACTOR);
+            return System.lineSeparator() + new JSONObject(responseContent).toString(JSON_INDENT_FACTOR);
         } catch (JSONException e) {
             JobLogger.getInstance().log("Cannot parse JSON response: %s", e.getMessage());
+            return System.lineSeparator() + responseContent;
         }
-        JobLogger.getInstance().log("Response content: %s%s", System.lineSeparator(), jsonContent == null ? responseContent : jsonContent);
-        return responseContent;
+    }
+
+    /**
+     * Compact representation of a Microsoft Graph response. Optimized for two shapes:
+     * <ul>
+     *   <li>Collection responses (have {@code value} array) — emitted as a count header followed
+     *       by one line per entity with the fields in {@link #SUMMARY_FIELDS} that are present.
+     *       Capped at {@link #MAX_SUMMARY_ENTRIES} with a "+N more" suffix.</li>
+     *   <li>Single-entity responses (e.g. {@code /users/{id}}, {@code /organization}) — kept as
+     *       pretty-printed JSON since they're inherently small and the full payload is the most
+     *       useful representation.</li>
+     * </ul>
+     * On {@link JSONException} (malformed body) falls back to a {@link #MAX_RAW_FALLBACK_CHARS}-truncated
+     * raw dump so an operator still has something to diagnose with.
+     */
+    @VisibleForTesting
+    static String summarizeJsonResponse(String responseContent) {
+        try {
+            JSONObject root = new JSONObject(responseContent);
+            Object value = root.opt("value");
+            if (!(value instanceof JSONArray array)) {
+                // Single-entity response — keep the existing pretty-printed shape; it's small.
+                return System.lineSeparator() + root.toString(JSON_INDENT_FACTOR);
+            }
+            return summarizeArray(array, root.has("@odata.nextLink"));
+        } catch (JSONException e) {
+            return truncate(responseContent, MAX_RAW_FALLBACK_CHARS);
+        }
+    }
+
+    private static String summarizeArray(JSONArray array, boolean paginated) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(array.length()).append(" entit").append(array.length() == 1 ? "y" : "ies");
+        if (paginated) {
+            sb.append(" (paginated)");
+        }
+        if (array.length() == 0) {
+            return sb.toString();
+        }
+        sb.append(':');
+        int sample = Math.min(array.length(), MAX_SUMMARY_ENTRIES);
+        for (int i = 0; i < sample; i++) {
+            sb.append(System.lineSeparator()).append("  - ").append(summarizeEntity(array.opt(i)));
+        }
+        if (array.length() > sample) {
+            sb.append(System.lineSeparator())
+              .append("  ... +").append(array.length() - sample)
+              .append(" more (set <verboseGraphLog>true</verboseGraphLog> to see full payload)");
+        }
+        return sb.toString();
+    }
+
+    private static String summarizeEntity(Object item) {
+        if (!(item instanceof JSONObject obj)) {
+            return String.valueOf(item);
+        }
+        StringBuilder out = new StringBuilder();
+        for (String field : SUMMARY_FIELDS) {
+            if (!obj.has(field) || obj.isNull(field)) {
+                continue;
+            }
+            String rendered = String.valueOf(obj.opt(field));
+            if (rendered.isEmpty()) {
+                continue;
+            }
+            if (out.length() > 0) {
+                out.append(' ');
+            }
+            out.append(field).append("=\"").append(rendered).append('"');
+        }
+        // No known field present (atypical for Graph entities, but possible for opaque types):
+        // fall back to the inline JSON so the operator still sees what came back.
+        return out.length() == 0 ? obj.toString() : out.toString();
+    }
+
+    private static String truncate(String s, int maxLen) {
+        if (s == null || s.length() <= maxLen) {
+            return s;
+        }
+        return s.substring(0, maxLen) + "... [+" + (s.length() - maxLen)
+                + " more chars; set <verboseGraphLog>true</verboseGraphLog> to see full payload]";
     }
 
     private String getResponseStatusLine(Response response) {

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPatterns.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPatterns.java
@@ -14,6 +14,9 @@ import java.util.Map;
  * compilation is intentionally deferred to the job's initialization step so {@code
  * PatternSyntaxException} can be reported as a configuration error against the specific offending
  * pattern instead of failing here on the parameter conversion path.
+ *
+ * <p>Mirrors {@link GroupPrefixes} for the Polarion-shape dispatch in {@link #fromRawValue(Object)}
+ * — see that class's javadoc for the {@code Map}/{@code List}/blank shapes Polarion can deliver.
  */
 @Data
 public class GroupPatterns {
@@ -21,19 +24,38 @@ public class GroupPatterns {
 
     private final @NotNull List<String> patterns;
 
+    /**
+     * Direct constructor for production code and tests that already have the pattern list in
+     * hand. Polarion's marshaller goes through {@link #fromRawValue(Object)} instead.
+     *
+     * <p>Defensive {@link ArrayList} copy — tolerates {@code null} entries (which
+     * {@link List#copyOf} rejects) and decouples from the source list's mutability. Null/blank
+     * entries are dropped later in {@code UserSynchronizationJobUnit} init.
+     */
+    public GroupPatterns(@NotNull List<String> patterns) {
+        this.patterns = Collections.unmodifiableList(new ArrayList<>(patterns));
+    }
+
+    /**
+     * @param rawValue the value Polarion's job-parameter marshaller hands to {@code convertValue}
+     * @return a wrapper for any recognized Polarion shape, or {@code null} when the parameter
+     *         should be treated as not provided (absent, blank, or wrong type)
+     */
     @SuppressWarnings("unchecked")
-    public GroupPatterns(@Nullable Map<?, ?> parameters) {
-        if (parameters == null) {
-            this.patterns = Collections.emptyList();
-            return;
-        }
-        // Defensive copy via ArrayList for the List branch: tolerates null entries (which
-        // List.copyOf rejects) and decouples from the source list's mutability.
-        // UserSynchronizationJobUnit drops null/blank entries during init.
-        this.patterns = switch (parameters.get(GROUP_PATTERN_NAME)) {
-            case List<?> list -> Collections.unmodifiableList(new ArrayList<>((List<String>) list));
-            case String s -> List.of(s);
-            case null, default -> Collections.emptyList();
+    public static @Nullable GroupPatterns fromRawValue(@Nullable Object rawValue) {
+        return switch (rawValue) {
+            case Map<?, ?> map -> fromMap(map);
+            case List<?> list -> new GroupPatterns((List<String>) list);
+            case null, default -> null;
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    private static GroupPatterns fromMap(Map<?, ?> map) {
+        return switch (map.get(GROUP_PATTERN_NAME)) {
+            case List<?> list -> new GroupPatterns((List<String>) list);
+            case String s -> new GroupPatterns(List.of(s));
+            case null, default -> new GroupPatterns(Collections.emptyList());
         };
     }
 }

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPrefixes.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPrefixes.java
@@ -10,12 +10,25 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Job-parameter wrapper for the {@code <groupPrefixes>} list. Mirrors the {@link
- * ch.sbb.polarion.extension.aad.synchronizer.filter.Whitelist} pattern: Polarion delivers the
- * nested XML as a {@link Map} keyed by the inner element name (here, {@code groupPrefix}). Single
- * children come through as a bare {@link String}; multiple children come through as a {@link
- * List}. Both shapes collapse to a {@code List<String>} here so callers can ignore the
- * difference.
+ * Job-parameter wrapper for the {@code <groupPrefixes>} list.
+ *
+ * <p>Polarion's {@code com.polarion.platform.jobs.internal.service.scheduler.ScheduleDataHandler}
+ * delivers different shapes for the {@code <groupPrefixes>} element depending on its child
+ * structure (see {@code parseParameter} in that class — the algorithm is: empty element → text;
+ * children with distinct tag names → {@code Map}; two-or-more children sharing a tag name →
+ * {@code List}, with the inner element name discarded). The shapes that reach
+ * {@link #fromRawValue(Object)} are therefore:
+ *
+ * <ul>
+ *   <li>{@code Map} — the element has exactly one child, e.g.
+ *       {@code <groupPrefixes><groupPrefix>X</groupPrefix></groupPrefixes>} arrives as
+ *       {@code {groupPrefix=X}}.</li>
+ *   <li>{@code List} — the element has 2+ children with the same tag name, e.g.
+ *       {@code <groupPrefixes><groupPrefix>X</groupPrefix><groupPrefix>Y</groupPrefix></groupPrefixes>}
+ *       arrives as {@code [X, Y]} (the inner tag name is dropped). Treating this shape as
+ *       "parameter not provided" is the bug fixed in this class — see issue history.</li>
+ *   <li>{@code String} (blank) or {@code null} — empty/absent element.</li>
+ * </ul>
  */
 @Data
 public class GroupPrefixes {
@@ -23,19 +36,38 @@ public class GroupPrefixes {
 
     private final @NotNull List<String> prefixes;
 
+    /**
+     * Direct constructor for production code and tests that already have the prefix list in hand.
+     * Polarion's marshaller goes through {@link #fromRawValue(Object)} instead.
+     *
+     * <p>Defensive {@link ArrayList} copy — tolerates {@code null} entries (which
+     * {@link List#copyOf} rejects) and decouples from the source list's mutability. Null/blank
+     * entries are dropped later in {@code UserSynchronizationJobUnit} init.
+     */
+    public GroupPrefixes(@NotNull List<String> prefixes) {
+        this.prefixes = Collections.unmodifiableList(new ArrayList<>(prefixes));
+    }
+
+    /**
+     * @param rawValue the value Polarion's job-parameter marshaller hands to {@code convertValue}
+     * @return a wrapper for any recognized Polarion shape, or {@code null} when the parameter
+     *         should be treated as not provided (absent, blank, or wrong type)
+     */
     @SuppressWarnings("unchecked")
-    public GroupPrefixes(@Nullable Map<?, ?> parameters) {
-        if (parameters == null) {
-            this.prefixes = Collections.emptyList();
-            return;
-        }
-        // Defensive copy via ArrayList for the List branch: tolerates null entries (which
-        // List.copyOf rejects) and decouples from the source list's mutability.
-        // UserSynchronizationJobUnit drops null/blank entries during init.
-        this.prefixes = switch (parameters.get(GROUP_PREFIX_NAME)) {
-            case List<?> list -> Collections.unmodifiableList(new ArrayList<>((List<String>) list));
-            case String s -> List.of(s);
-            case null, default -> Collections.emptyList();
+    public static @Nullable GroupPrefixes fromRawValue(@Nullable Object rawValue) {
+        return switch (rawValue) {
+            case Map<?, ?> map -> fromMap(map);
+            case List<?> list -> new GroupPrefixes((List<String>) list);
+            case null, default -> null;
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    private static GroupPrefixes fromMap(Map<?, ?> map) {
+        return switch (map.get(GROUP_PREFIX_NAME)) {
+            case List<?> list -> new GroupPrefixes((List<String>) list);
+            case String s -> new GroupPrefixes(List.of(s));
+            case null, default -> new GroupPrefixes(Collections.emptyList());
         };
     }
 }

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/service/GraphService.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/service/GraphService.java
@@ -55,9 +55,12 @@ public class GraphService implements IGraphService {
         }
 
         if (selected.isEmpty()) {
-            // Both branches yielded nothing — fail loudly rather than handing an empty set to
-            // PolarionService.deletePolarionUsers (which would wipe every AAD-managed account).
-            throw new NotFoundException("No AAD groups matched the configured groupPrefixes/groupPatterns.");
+            // Every configured selector yielded nothing — fail loudly rather than handing an
+            // empty set to PolarionService.deletePolarionUsers (which would wipe every
+            // AAD-managed account). Tailor the message to what was actually configured so an
+            // operator on the patterns-only path doesn't see the confusing "groupPrefixes/..."
+            // wording.
+            throw new NotFoundException("No AAD groups matched the configured " + describeSelectors(hasPrefixes, hasPatterns) + ".");
         }
         if (hasPrefixes && hasPatterns) {
             JobLogger.getInstance().log("%d unique group(s) after union of groupPrefixes and groupPatterns",
@@ -67,6 +70,13 @@ public class GraphService implements IGraphService {
         Set<String> members = getAadMemberIds(selected.values());
         JobLogger.getInstance().log("%d unique member(s) in AAD for Polarion have been found", members.size());
         return members;
+    }
+
+    private static String describeSelectors(boolean hasPrefixes, boolean hasPatterns) {
+        if (hasPrefixes && hasPatterns) {
+            return "groupPrefixes/groupPatterns";
+        }
+        return hasPrefixes ? "groupPrefixes" : "groupPatterns";
     }
 
     private void collectGroupsByPrefixes(List<String> groupPrefixes, boolean hasPatterns, Map<String, Group> sink) {

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/service/GraphService.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/service/GraphService.java
@@ -10,7 +10,11 @@ import ch.sbb.polarion.extension.generic.util.JobLogger;
 import lombok.AllArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -20,35 +24,91 @@ import java.util.stream.Collectors;
 public class GraphService implements IGraphService {
     private final IGraphConnector graphConnector;
 
+    /**
+     * Resolves the union of AAD members covered by the configured selectors.
+     *
+     * <p>Selector semantics — each acts as an independent OR-source:
+     * <ul>
+     *   <li>{@code groupPrefixes} only — one Graph request with a server-side
+     *       {@code startswith($filter)}.</li>
+     *   <li>{@code groupPatterns} only — one unfiltered Graph request, regex applied client-side.</li>
+     *   <li>both — both requests are issued and the resulting groups are unioned by id. This lets
+     *       a configuration include a broad prefix family <em>plus</em> outliers captured only by a
+     *       pattern, without forcing every group to satisfy both selectors.</li>
+     * </ul>
+     *
+     * <p>The job init layer (see {@code UserSynchronizationJobUnit#initializationCheck}) guarantees
+     * at least one selector is non-empty, so the "both empty" branch is unreachable here.
+     */
     @Override
     public Set<String> getAadMemberIds(@NotNull List<String> groupPrefixes, @NotNull List<Pattern> groupPatterns) {
-        List<Group> groups = graphConnector.getGroups(groupPrefixes);
-        JobLogger.getInstance().log("%d group(s) returned by Microsoft Graph for prefixes %s",
-                groups.size(), groupPrefixes.isEmpty() ? "[]" : groupPrefixes);
+        boolean hasPrefixes = !groupPrefixes.isEmpty();
+        boolean hasPatterns = !groupPatterns.isEmpty();
 
-        if (!groupPatterns.isEmpty()) {
-            List<Group> matched = groups.stream()
-                    .filter(g -> g.getDisplayName() != null
-                            && groupPatterns.stream().anyMatch(p -> p.matcher(g.getDisplayName()).matches()))
-                    .toList();
-            JobLogger.getInstance().log("%d group(s) matched %d pattern(s)", matched.size(), groupPatterns.size());
-            if (matched.isEmpty()) {
-                throw new NotFoundException("No AAD groups matched the configured groupPatterns.");
-            }
-            groups = matched;
+        Map<String, Group> selected = new LinkedHashMap<>();
+
+        if (hasPrefixes) {
+            collectGroupsByPrefixes(groupPrefixes, hasPatterns, selected);
+        }
+        if (hasPatterns) {
+            collectGroupsByPatterns(groupPatterns, selected);
         }
 
-        Set<String> members = getAadMemberIds(groups);
+        if (selected.isEmpty()) {
+            // Both branches yielded nothing — fail loudly rather than handing an empty set to
+            // PolarionService.deletePolarionUsers (which would wipe every AAD-managed account).
+            throw new NotFoundException("No AAD groups matched the configured groupPrefixes/groupPatterns.");
+        }
+        if (hasPrefixes && hasPatterns) {
+            JobLogger.getInstance().log("%d unique group(s) after union of groupPrefixes and groupPatterns",
+                    selected.size());
+        }
 
+        Set<String> members = getAadMemberIds(selected.values());
         JobLogger.getInstance().log("%d unique member(s) in AAD for Polarion have been found", members.size());
         return members;
     }
 
-    private Set<String> getAadMemberIds(List<Group> groups) {
-        List<String> groupKeys = groups.stream()
-                .map(Group::getId)
-                .toList();
+    private void collectGroupsByPrefixes(List<String> groupPrefixes, boolean hasPatterns, Map<String, Group> sink) {
+        try {
+            List<Group> byPrefix = graphConnector.getGroups(groupPrefixes);
+            JobLogger.getInstance().log("%d group(s) returned by Microsoft Graph for prefixes %s",
+                    byPrefix.size(), groupPrefixes);
+            byPrefix.forEach(g -> sink.putIfAbsent(g.getId(), g));
+        } catch (NotFoundException e) {
+            // GraphConnector#getGroups throws NotFoundException when the prefix filter matched
+            // zero groups. When patterns are also configured, the union may still be non-empty,
+            // so swallow here and let the bottom-of-method check decide. When patterns aren't
+            // configured the swallow would mask the only signal, so re-throw.
+            if (!hasPatterns) {
+                throw e;
+            }
+            JobLogger.getInstance().log(
+                    "groupPrefixes %s matched no AAD groups; relying on groupPatterns to populate the result.",
+                    groupPrefixes);
+        }
+    }
 
+    private void collectGroupsByPatterns(List<Pattern> groupPatterns, Map<String, Group> sink) {
+        // No $filter — let Graph stream every group; patterns are evaluated locally below. Any
+        // server-side narrowing belongs to groupPrefixes; mixing the two filters in one request
+        // would defeat the union semantics.
+        List<Group> all = graphConnector.getGroups(List.of());
+        JobLogger.getInstance().log("%d group(s) returned by Microsoft Graph (unfiltered fetch for patterns)",
+                all.size());
+        List<Group> matched = all.stream()
+                .filter(g -> g.getDisplayName() != null
+                        && groupPatterns.stream().anyMatch(p -> p.matcher(g.getDisplayName()).matches()))
+                .toList();
+        JobLogger.getInstance().log("%d group(s) matched %d pattern(s)", matched.size(), groupPatterns.size());
+        matched.forEach(g -> sink.putIfAbsent(g.getId(), g));
+    }
+
+    private Set<String> getAadMemberIds(Collection<Group> groups) {
+        List<String> groupKeys = new ArrayList<>(groups.size());
+        for (Group g : groups) {
+            groupKeys.add(g.getId());
+        }
         return groupKeys.stream()
                 .flatMap(key -> graphConnector.getMembers(key).stream())
                 .map(Member::getId)

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactoryTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactoryTest.java
@@ -30,36 +30,47 @@ class AADUserSynchronizationJobUnitFactoryTest {
     }
 
     @Test
-    void groupPrefixesParameterConvertsMapToWrapperAndRejectsOtherShapes() {
-        // The convertValue lambda is what Polarion calls when it has finished marshalling the
-        // <groupPrefixes> XML block into a Map. Anything other than a Map (e.g. a stray String)
-        // must round-trip to null so the job's mutual-exclusion logic treats the parameter as
-        // "not provided" rather than throwing.
+    void groupPrefixesParameterAcceptsBothPolarionShapes() {
+        // The convertValue lambda is what Polarion calls after marshalling the <groupPrefixes>
+        // XML block. Polarion delivers two distinct shapes depending on how many children the
+        // block has — both must round-trip into a populated GroupPrefixes wrapper.
         IJobParameter param = new AADUserSynchronizationJobUnitFactory()
                 .getJobDescriptor(null)
                 .getParameter(GROUP_PREFIXES);
 
-        Object converted = param.convertValue(Map.of(GroupPrefixes.GROUP_PREFIX_NAME, List.of("A_", "B_")));
-        assertThat(converted)
+        // Single child: <groupPrefixes><groupPrefix>X</groupPrefix></groupPrefixes>
+        // Polarion#parseMapParameter delivers {groupPrefix=X}.
+        assertThat(param.convertValue(Map.of(GroupPrefixes.GROUP_PREFIX_NAME, "ONLY_")))
+                .isInstanceOfSatisfying(GroupPrefixes.class,
+                        gp -> assertThat(gp.getPrefixes()).containsExactly("ONLY_"));
+
+        // Multi-child same-tag: <groupPrefixes><groupPrefix>A_</groupPrefix><groupPrefix>B_</groupPrefix></groupPrefixes>
+        // Polarion#parseListParameter delivers a bare List ["A_", "B_"]. Regression: this was
+        // silently rejected when convertValue only accepted Map.
+        assertThat(param.convertValue(List.of("A_", "B_")))
                 .isInstanceOfSatisfying(GroupPrefixes.class,
                         gp -> assertThat(gp.getPrefixes()).containsExactly("A_", "B_"));
 
-        assertThat(param.convertValue("not-a-map")).isNull();
+        // Anything else (blank string, scalar, null) → "not provided".
+        assertThat(param.convertValue("not-a-shape")).isNull();
         assertThat(param.convertValue(null)).isNull();
     }
 
     @Test
-    void groupPatternsParameterConvertsMapToWrapperAndRejectsOtherShapes() {
+    void groupPatternsParameterAcceptsBothPolarionShapes() {
         IJobParameter param = new AADUserSynchronizationJobUnitFactory()
                 .getJobDescriptor(null)
                 .getParameter(GROUP_PATTERNS);
 
-        Object converted = param.convertValue(Map.of(GroupPatterns.GROUP_PATTERN_NAME, "^X_.*"));
-        assertThat(converted)
+        assertThat(param.convertValue(Map.of(GroupPatterns.GROUP_PATTERN_NAME, "^X_.*")))
                 .isInstanceOfSatisfying(GroupPatterns.class,
                         gp -> assertThat(gp.getPatterns()).containsExactly("^X_.*"));
 
-        assertThat(param.convertValue("not-a-map")).isNull();
+        assertThat(param.convertValue(List.of("^A_.*", "^B_.*")))
+                .isInstanceOfSatisfying(GroupPatterns.class,
+                        gp -> assertThat(gp.getPatterns()).containsExactly("^A_.*", "^B_.*"));
+
+        assertThat(param.convertValue("not-a-shape")).isNull();
         assertThat(param.convertValue(null)).isNull();
     }
 

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactoryTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactoryTest.java
@@ -23,7 +23,7 @@ class AADUserSynchronizationJobUnitFactoryTest {
 
         assertThat(descriptor.getLabel()).isEqualTo("Synchronization job");
         Stream.of(AUTHENTICATION_PROVIDER_ID, GROUP_PREFIX, GROUP_PREFIXES, GROUP_PATTERNS,
-                DRY_RUN, CHECK_LAST_SYNCHRONIZATION,
+                DRY_RUN, CHECK_LAST_SYNCHRONIZATION, VERBOSE_GRAPH_LOG,
                 GRAPH_ID_FIELD, GRAPH_NAME_FIELD, GRAPH_EMAIL_FIELD).forEach(
                 param -> assertThat(descriptor.getParameter(param)).isNotNull()
         );

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnitTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnitTest.java
@@ -164,9 +164,9 @@ class UserSynchronizationJobUnitTest {
             // The ownGraphConnector branch must have actually constructed a GraphConnector —
             // otherwise the try-with-resources line would never execute in any test.
             assertThat(graphMock.constructed()).hasSize(1);
-            // verboseGraphLog flows from job parameter into the freshly-constructed connector;
-            // pinning the call here so a future refactor that drops the wiring (e.g. moves
-            // logging config out of GraphConnector) can't silently regress the toggle.
+            // Pin the wiring of verboseGraphLog from the job parameter into the freshly built
+            // connector. Without this verification a future refactor that drops the propagation
+            // could silently regress the operator-facing toggle.
             verify(graphMock.constructed().get(0)).setVerboseLog(true);
             verify(polarionService).createPolarionUsers(List.of("ownNick"));
         }

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnitTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnitTest.java
@@ -36,7 +36,6 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -214,7 +213,7 @@ class UserSynchronizationJobUnitTest {
         // the legacy <groupPrefix> in place must surface as a configuration error rather than
         // silently picking one of the two.
         userSynchronizationJobUnit.setGroupPrefix("legacyPrefix");
-        userSynchronizationJobUnit.setGroupPrefixes(new GroupPrefixes(Map.of(GroupPrefixes.GROUP_PREFIX_NAME, List.of("A_", "B_"))));
+        userSynchronizationJobUnit.setGroupPrefixes(new GroupPrefixes(List.of("A_", "B_")));
 
         try (MockedStatic<AuthenticationManager> mockedAuthenticationManager = Mockito.mockStatic(AuthenticationManager.class, RETURNS_DEEP_STUBS)) {
             mockedAuthenticationManager.when(() -> AuthenticationManager.getInstance().authenticators())
@@ -229,7 +228,7 @@ class UserSynchronizationJobUnitTest {
         // An invalid regex should fail the job at start with a clear configuration error rather
         // than throwing PatternSyntaxException deep inside the run.
         userSynchronizationJobUnit.setGroupPrefix(null);
-        userSynchronizationJobUnit.setGroupPatterns(new GroupPatterns(Map.of(GroupPatterns.GROUP_PATTERN_NAME, "[invalid(")));
+        userSynchronizationJobUnit.setGroupPatterns(new GroupPatterns(List.of("[invalid(")));
 
         try (MockedStatic<AuthenticationManager> mockedAuthenticationManager = Mockito.mockStatic(AuthenticationManager.class, RETURNS_DEEP_STUBS)) {
             mockedAuthenticationManager.when(() -> AuthenticationManager.getInstance().authenticators())
@@ -249,7 +248,7 @@ class UserSynchronizationJobUnitTest {
             tooMany.add("PREFIX_" + i + "_");
         }
         userSynchronizationJobUnit.setGroupPrefix(null);
-        userSynchronizationJobUnit.setGroupPrefixes(new GroupPrefixes(Map.of(GroupPrefixes.GROUP_PREFIX_NAME, tooMany)));
+        userSynchronizationJobUnit.setGroupPrefixes(new GroupPrefixes(tooMany));
 
         try (MockedStatic<AuthenticationManager> mockedAuthenticationManager = Mockito.mockStatic(AuthenticationManager.class, RETURNS_DEEP_STUBS)) {
             mockedAuthenticationManager.when(() -> AuthenticationManager.getInstance().authenticators())
@@ -266,7 +265,7 @@ class UserSynchronizationJobUnitTest {
         // the pattern actually filters groups before resolving members and that only patterns
         // (no prefixes) is a valid configuration.
         userSynchronizationJobUnit.setGroupPrefix(null);
-        userSynchronizationJobUnit.setGroupPatterns(new GroupPatterns(Map.of(GroupPatterns.GROUP_PATTERN_NAME, "^SOME(_OTHER)?_GROUP_PREFIX_.*")));
+        userSynchronizationJobUnit.setGroupPatterns(new GroupPatterns(List.of("^SOME(_OTHER)?_GROUP_PREFIX_.*")));
 
         try (MockedStatic<TransactionalExecutor> mockedExecutor = Mockito.mockStatic(TransactionalExecutor.class);
              MockedStatic<OSGiUtils> mockedOSGiUtils = Mockito.mockStatic(OSGiUtils.class);
@@ -311,7 +310,7 @@ class UserSynchronizationJobUnitTest {
         // The legacy singular setter must NOT be set in the same job (mutual exclusion is covered
         // by a dedicated test above), so reset it here.
         userSynchronizationJobUnit.setGroupPrefix(null);
-        userSynchronizationJobUnit.setGroupPrefixes(new GroupPrefixes(Map.of(GroupPrefixes.GROUP_PREFIX_NAME, List.of("LEGACY_", "NEW_"))));
+        userSynchronizationJobUnit.setGroupPrefixes(new GroupPrefixes(List.of("LEGACY_", "NEW_")));
 
         try (MockedStatic<TransactionalExecutor> mockedExecutor = Mockito.mockStatic(TransactionalExecutor.class);
              MockedStatic<OSGiUtils> mockedOSGiUtils = Mockito.mockStatic(OSGiUtils.class);
@@ -364,8 +363,8 @@ class UserSynchronizationJobUnitTest {
         patternsWithBlanks.add("   ");
 
         userSynchronizationJobUnit.setGroupPrefix(null);
-        userSynchronizationJobUnit.setGroupPrefixes(new GroupPrefixes(Map.of(GroupPrefixes.GROUP_PREFIX_NAME, prefixesWithBlanks)));
-        userSynchronizationJobUnit.setGroupPatterns(new GroupPatterns(Map.of(GroupPatterns.GROUP_PATTERN_NAME, patternsWithBlanks)));
+        userSynchronizationJobUnit.setGroupPrefixes(new GroupPrefixes(prefixesWithBlanks));
+        userSynchronizationJobUnit.setGroupPatterns(new GroupPatterns(patternsWithBlanks));
 
         try (MockedStatic<TransactionalExecutor> mockedExecutor = Mockito.mockStatic(TransactionalExecutor.class);
              MockedStatic<OSGiUtils> mockedOSGiUtils = Mockito.mockStatic(OSGiUtils.class);

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnitTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnitTest.java
@@ -155,6 +155,8 @@ class UserSynchronizationJobUnitTest {
             mockedAuthenticationManager.when(() -> AuthenticationManager.getInstance().authenticators())
                     .thenReturn(List.of(authenticationProviderConfiguration));
 
+            jobUnit.setVerboseGraphLog(true);
+
             IJobStatus jobStatus = jobUnit.runInternal(monitor);
 
             assertThat(jobStatus).isNotNull();
@@ -162,6 +164,10 @@ class UserSynchronizationJobUnitTest {
             // The ownGraphConnector branch must have actually constructed a GraphConnector —
             // otherwise the try-with-resources line would never execute in any test.
             assertThat(graphMock.constructed()).hasSize(1);
+            // verboseGraphLog flows from job parameter into the freshly-constructed connector;
+            // pinning the call here so a future refactor that drops the wiring (e.g. moves
+            // logging config out of GraphConnector) can't silently regress the toggle.
+            verify(graphMock.constructed().get(0)).setVerboseLog(true);
             verify(polarionService).createPolarionUsers(List.of("ownNick"));
         }
     }
@@ -382,10 +388,15 @@ class UserSynchronizationJobUnitTest {
                     });
             mockedOSGiUtils.when(() -> OSGiUtils.lookupOSGiService(IPolarionServiceFactory.class))
                     .thenReturn((IPolarionServiceFactory) (s, p, d, ids) -> polarionService);
-            // Connector must be called with the cleaned single-element list, not the original
-            // four-element list with blanks. If cleanup is broken, this stub won't match and
-            // the job log will show getGroups returning an empty result → NotFoundException.
+            // Both selectors are configured, so under the union semantics the connector receives
+            // two calls: getGroups(List.of("KEEP_")) for the prefix branch (server-side $filter)
+            // and getGroups(List.of()) for the pattern branch (unfiltered tenant fetch). Both
+            // arguments must match the cleaned-up list — if cleanup is broken either stub won't
+            // match and the run fails with NotFoundException from the connector.
             when(externalGraphConnector.getGroups(List.of("KEEP_"))).thenReturn(List.of(
+                    new Group("g1", "KEEP_GROUP")
+            ));
+            when(externalGraphConnector.getGroups(List.of())).thenReturn(List.of(
                     new Group("g1", "KEEP_GROUP")
             ));
             when(externalGraphConnector.getMembers("g1")).thenReturn(List.of(new Member("u1", "n", "e")));

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
@@ -400,10 +400,8 @@ class GraphConnectorIT {
         log("  prefix-union members = " + prefixUnion.size() + " id(s)");
 
         assertThat(viaService)
-                .as("union semantics: result must contain the target group's members (regex branch)")
-                .containsAll(targetMembers);
-        assertThat(viaService)
-                .as("union semantics: result must equal the prefix branch members when the regex match is a subset")
+                .as("union semantics: result must include the target group's members (regex branch) and equal the prefix branch members when the regex match is a subset of prefixes")
+                .containsAll(targetMembers)
                 .isEqualTo(prefixUnion);
     }
 

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorIT.java
@@ -369,52 +369,68 @@ class GraphConnectorIT {
     }
 
     /**
-     * Combined prefix + pattern path: {@code groupPrefixes} narrows server-side and a
-     * regex narrows client-side. Constructs a regex from a real {@code displayName} returned by
-     * Graph (escaped via {@code Pattern.quote}) so the test target is the first group exactly,
-     * then asserts that {@link GraphService#getAadMemberIds(java.util.List, java.util.List)}
-     * resolves the same member id set as a direct {@link GraphConnector#getMembers(String)} call
-     * against that one group.
+     * Combined prefix + pattern path under the union semantics: prefixes and patterns are
+     * independent OR-sources. Pins the contract that a regex captures additional groups beyond
+     * the prefix family without losing the prefix-resolved members. The test picks the first
+     * group of the prefix family as the target, builds a literal regex against its displayName,
+     * and asserts the union result is at least the prefix-resolved set (the regex matches a
+     * subset already covered by prefixes here, so the union equals the prefix branch).
      */
     @Test
-    void getAadMemberIdsCombinesPrefixAndPattern() {
+    void getAadMemberIdsUnionsPrefixAndPattern() {
         List<Group> groups = connector.getGroups(List.of(groupPrefix));
         assertThat(groups).hasSizeGreaterThanOrEqualTo(1);
         Group target = groups.get(0);
         Pattern onlyTarget = Pattern.compile("^" + Pattern.quote(target.getDisplayName()) + "$");
-        log("--- combined prefix+pattern: prefix='" + groupPrefix + "' pattern='" + onlyTarget.pattern() + "' ---");
+        log("--- union prefix+pattern: prefix='" + groupPrefix + "' pattern='" + onlyTarget.pattern() + "' ---");
 
         Set<String> viaService = new GraphService(connector).getAadMemberIds(List.of(groupPrefix), List.of(onlyTarget));
-        Set<String> direct = connector.getMembers(target.getId()).stream()
+        Set<String> targetMembers = connector.getMembers(target.getId()).stream()
+                .map(Member::getId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        Set<String> prefixUnion = groups.stream()
+                .flatMap(g -> connector.getMembers(g.getId()).stream())
                 .map(Member::getId)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());
 
-        log("  via GraphService = " + viaService.size() + " id(s)");
-        log("  direct getMembers = " + direct.size() + " id(s)");
+        log("  via GraphService    = " + viaService.size() + " id(s)");
+        log("  target members      = " + targetMembers.size() + " id(s)");
+        log("  prefix-union members = " + prefixUnion.size() + " id(s)");
 
         assertThat(viaService)
-                .as("client-side regex must select exactly the target group — its members equal direct getMembers")
-                .isEqualTo(direct);
+                .as("union semantics: result must contain the target group's members (regex branch)")
+                .containsAll(targetMembers);
+        assertThat(viaService)
+                .as("union semantics: result must equal the prefix branch members when the regex match is a subset")
+                .isEqualTo(prefixUnion);
     }
 
     /**
-     * Empty result after the regex filter must surface as a {@link NotFoundException} rather than
-     * a silent empty member set. A silent empty set would propagate into Polarion as "delete every
-     * user", because {@code deletePolarionUsers} treats the parameter as the keep-list. The unit
-     * test covers the same contract on mocks.
+     * Empty union must surface as {@link NotFoundException} rather than a silent empty member set.
+     * A silent empty set would propagate into Polarion as "delete every user", because
+     * {@code deletePolarionUsers} treats the parameter as the keep-list. Under the union
+     * semantics, both selectors must yield zero groups for the throw to fire — this test forces
+     * that by combining a sentinel prefix that nothing in the tenant starts with and an
+     * impossible regex.
      */
     @Test
-    void getAadMemberIdsThrowsWhenPatternMatchesNothing() {
+    void getAadMemberIdsThrowsWhenUnionIsEmpty() {
+        String sentinelPrefix = "__no_aad_group_starts_with_this_sentinel__";
         Pattern impossible = Pattern.compile("^__no_group_should_ever_match_this_sentinel__$");
-        log("--- pattern-matches-nothing: prefix='" + groupPrefix + "' pattern='" + impossible.pattern() + "' ---");
+        log("--- empty-union: prefix='" + sentinelPrefix + "' pattern='" + impossible.pattern() + "' ---");
         GraphService service = new GraphService(connector);
-        List<String> prefixes = List.of(groupPrefix);
+        List<String> prefixes = List.of(sentinelPrefix);
         List<Pattern> patterns = List.of(impossible);
 
+        // The prefix-only branch in GraphConnector throws NotFoundException("No AAD groups
+        // were found.") on its own. GraphService swallows that when patterns are also
+        // configured and re-throws a unified message after the pattern branch also yielded
+        // nothing — that's the contract this test pins.
         assertThatThrownBy(() -> service.getAadMemberIds(prefixes, patterns))
                 .isInstanceOf(NotFoundException.class)
-                .hasMessageContaining("groupPatterns");
+                .hasMessageContaining("groupPrefixes/groupPatterns");
     }
 
     /**
@@ -488,10 +504,13 @@ class GraphConnectorIT {
         Group b = groups.get(1);
         Pattern pa = Pattern.compile("^" + Pattern.quote(a.getDisplayName()) + "$");
         Pattern pb = Pattern.compile("^" + Pattern.quote(b.getDisplayName()) + "$");
-        log("--- multi-pattern: a='" + a.getDisplayName() + "' b='" + b.getDisplayName() + "' ---");
+        log("--- multi-pattern (patterns-only): a='" + a.getDisplayName() + "' b='" + b.getDisplayName() + "' ---");
 
+        // Patterns-only path so the regex selection isn't masked by the prefix branch's wider
+        // result under union semantics. The full-tenant fetch + the two literal regexes must
+        // resolve to exactly groups a and b.
         Set<String> viaService = new GraphService(connector)
-                .getAadMemberIds(List.of(groupPrefix), List.of(pa, pb));
+                .getAadMemberIds(List.of(), List.of(pa, pb));
 
         Set<String> directA = connector.getMembers(a.getId()).stream()
                 .map(Member::getId).filter(Objects::nonNull).collect(Collectors.toSet());
@@ -506,6 +525,62 @@ class GraphConnectorIT {
         assertThat(viaService)
                 .as("two patterns OR-combined must resolve to the union of the two matched groups' members")
                 .isEqualTo(union);
+    }
+
+    /**
+     * Disjoint-coverage union IT: the prefix branch covers some groups and the pattern branch
+     * captures an "outlier" the prefix doesn't cover, so the union strictly contains both
+     * branches' contributions. Pins the use case the new union semantics was designed for —
+     * "broad family by prefix plus outliers by regex".
+     *
+     * <p>Construction: pick two distinct groups under {@code groupPrefix}; build a server-side
+     * filter using the FULL displayName of the first group (which strictly excludes the second
+     * group from the prefix branch — {@code startswith(displayName, 'A')} returns A but not B
+     * when A and B share only {@code groupPrefix}); use a literal-quote regex against the
+     * second group's displayName so only it matches in the pattern branch. Skips with
+     * {@code assumeTrue} when the two displayNames overlap to the point that the strict prefix
+     * also matches the second group — that depends on the operator's tenant naming and isn't a
+     * test failure.
+     */
+    @Test
+    void getAadMemberIdsUnionsDisjointPrefixAndPatternCoverage() {
+        List<Group> groups = connector.getGroups(List.of(groupPrefix));
+        assumeTrue(groups.size() >= 2,
+                "tenant must expose at least 2 groups under prefix '" + groupPrefix + "' for the disjoint union test");
+
+        Group prefixOnly = groups.get(0);
+        Group patternOnly = groups.get(1);
+        String strictPrefix = prefixOnly.getDisplayName();
+        assumeTrue(!patternOnly.getDisplayName().startsWith(strictPrefix),
+                "tenant naming makes the strict prefix non-disjoint (group '"
+                        + patternOnly.getDisplayName() + "' starts with '" + strictPrefix
+                        + "'); pick a tenant where two groups don't share full displayName prefixes for this test to be meaningful");
+
+        Pattern outlierRegex = Pattern.compile("^" + Pattern.quote(patternOnly.getDisplayName()) + "$");
+        log("--- disjoint union: prefix='" + strictPrefix + "' pattern='" + outlierRegex.pattern() + "' ---");
+
+        Set<String> viaService = new GraphService(connector)
+                .getAadMemberIds(List.of(strictPrefix), List.of(outlierRegex));
+
+        Set<String> prefixMembers = connector.getMembers(prefixOnly.getId()).stream()
+                .map(Member::getId).filter(Objects::nonNull).collect(Collectors.toSet());
+        Set<String> patternMembers = connector.getMembers(patternOnly.getId()).stream()
+                .map(Member::getId).filter(Objects::nonNull).collect(Collectors.toSet());
+        Set<String> expectedUnion = new HashSet<>(prefixMembers);
+        expectedUnion.addAll(patternMembers);
+
+        log("  via GraphService = " + viaService.size() + " id(s)");
+        log("  expected union   = " + expectedUnion.size() + " id(s) (prefix=" + prefixMembers.size() + ", pattern=" + patternMembers.size() + ")");
+
+        // Both branches must contribute; equality (not just superset) pins that nothing else
+        // leaks in. This is the contract that distinguishes the new union semantics from the
+        // previous "prefix server-side, pattern narrows further" design — under the old design
+        // the pattern-only outlier would never show up in the result.
+        assertThat(viaService)
+                .as("disjoint union: result must contain both branches' members")
+                .containsAll(prefixMembers)
+                .containsAll(patternMembers)
+                .isEqualTo(expectedUnion);
     }
 
     /**

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorResponseSummaryTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorResponseSummaryTest.java
@@ -182,4 +182,61 @@ class GraphConnectorResponseSummaryTest {
 
         assertThat(summary).isEqualTo(body);
     }
+
+    @Test
+    void formatVerboseEmitsPrettyPrintedJsonForValidInput() {
+        // Verbose path: full pretty-printed JSON with one field per line, prefixed with the
+        // platform line separator. Pins the legacy debugging shape an operator gets when the
+        // <verboseGraphLog>true</verboseGraphLog> toggle is set.
+        String body = "{\"id\":\"g1\",\"displayName\":\"alpha\"}";
+
+        String formatted = GraphConnector.formatVerbose(body);
+
+        assertThat(formatted)
+                .startsWith(System.lineSeparator() + "{")
+                .contains("\"id\": \"g1\"")
+                .contains("\"displayName\": \"alpha\"");
+    }
+
+    @Test
+    void formatVerboseFallsBackToRawOnMalformedJson() {
+        // Verbose path's defensive recovery: if Graph ever returns something that isn't JSON
+        // (e.g. an HTML error page slipped past status checks), the verbose path must still
+        // hand the operator the raw payload instead of throwing — the surrounding logging is
+        // the only diagnostic anchor at that point.
+        String body = "<html>not json</html>";
+
+        String formatted = GraphConnector.formatVerbose(body);
+
+        assertThat(formatted).isEqualTo(System.lineSeparator() + body);
+    }
+
+    @Test
+    void summarizeEntityHandlesNonObjectArrayElements() {
+        // Defensive path in summarizeEntity: a value-array containing a bare scalar (atypical
+        // for /groups or /users responses, but possible for opaque shapes) must not crash the
+        // summarizer — it falls back to String.valueOf so the operator still sees something.
+        String body = "{\"value\":[\"raw-string\",42]}";
+
+        String summary = GraphConnector.summarizeJsonResponse(body);
+
+        assertThat(summary)
+                .startsWith("2 entities:")
+                .contains("raw-string")
+                .contains("42");
+    }
+
+    @Test
+    void summarizeEntitySkipsFieldsWithEmptyStringValue() {
+        // Defensive path in appendIfPresent: a present-but-empty field (Graph occasionally
+        // returns "" rather than null for unset properties) must be skipped so the summary
+        // doesn't degrade to displayName="" noise.
+        String body = "{\"value\":[{\"id\":\"g1\",\"displayName\":\"\"}]}";
+
+        String summary = GraphConnector.summarizeJsonResponse(body);
+
+        assertThat(summary)
+                .contains("id=\"g1\"")
+                .doesNotContain("displayName=\"\"");
+    }
 }

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorResponseSummaryTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorResponseSummaryTest.java
@@ -1,0 +1,185 @@
+package ch.sbb.polarion.extension.aad.synchronizer.connector;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit-level coverage of the compact log summarizer used when {@code verboseGraphLog=false}.
+ * Exercises the static {@code GraphConnector#summarizeJsonResponse} helper directly — the
+ * connector's WireMock end-to-end coverage in {@link GraphConnectorTest} would equally exercise
+ * it but at much higher overhead per assertion.
+ *
+ * <p>Documents the shapes the summarizer must handle without exploding the job log:
+ * <ul>
+ *   <li>collection responses ({@code value} array) — count header + one line per entity, capped
+ *       at {@code MAX_SUMMARY_ENTRIES} with a "+N more" suffix;</li>
+ *   <li>paginated responses ({@code @odata.nextLink}) — count header annotated with
+ *       "(paginated)" so the operator knows there's more behind the cursor;</li>
+ *   <li>single-entity responses (e.g. {@code /organization}) — full pretty-printed JSON because
+ *       the payload is inherently small;</li>
+ *   <li>malformed/non-JSON bodies — truncated raw dump as a diagnostic fallback.</li>
+ * </ul>
+ */
+class GraphConnectorResponseSummaryTest {
+
+    @Test
+    void collectionWithSingleEntityRendersHeaderAndOneLine() {
+        String body = """
+                {
+                    "@odata.context": "...",
+                    "value": [
+                        {"id": "55073b31", "displayName": "TEST_AAD_SYNC_polarion"}
+                    ]
+                }
+                """;
+
+        String summary = GraphConnector.summarizeJsonResponse(body);
+
+        assertThat(summary)
+                .startsWith("1 entity:")
+                .contains("id=\"55073b31\"")
+                .contains("displayName=\"TEST_AAD_SYNC_polarion\"");
+    }
+
+    @Test
+    void collectionWithMultipleEntitiesRendersOneLinePerEntry() {
+        String body = """
+                {
+                    "value": [
+                        {"id": "g1", "displayName": "A"},
+                        {"id": "g2", "displayName": "B"}
+                    ]
+                }
+                """;
+
+        String summary = GraphConnector.summarizeJsonResponse(body);
+
+        assertThat(summary).startsWith("2 entities:");
+        assertThat(summary.lines().count())
+                .as("one header line + one line per entity")
+                .isEqualTo(3);
+        assertThat(summary).contains("displayName=\"A\"").contains("displayName=\"B\"");
+    }
+
+    @Test
+    void usersResponsePicksUpEmployeeIdAndMail() {
+        // Mirrors the real /groups/{id}/members projection used by the job: id + employeeId
+        // (when graphIdField=employeeId) + displayName + mail. Pins that the summarizer surfaces
+        // each of those fields rather than collapsing to a generic id-only summary. Values are
+        // intentionally synthetic placeholders (no real-looking employee IDs or names) so the
+        // pre-commit sensitive-data-leak hook stays green.
+        String body = """
+                {
+                    "value": [
+                        {"id": "aad-1", "employeeId": "EMPLOYEE_ID_1", "displayName": "Test User One", "mail": "user.one@example.com"},
+                        {"id": "aad-2", "employeeId": "EMPLOYEE_ID_2", "displayName": "Test User Two", "mail": "user.two@example.com"}
+                    ]
+                }
+                """;
+
+        String summary = GraphConnector.summarizeJsonResponse(body);
+
+        assertThat(summary)
+                .contains("employeeId=\"EMPLOYEE_ID_1\"")
+                .contains("mail=\"user.one@example.com\"")
+                .contains("employeeId=\"EMPLOYEE_ID_2\"")
+                .contains("mail=\"user.two@example.com\"");
+    }
+
+    @Test
+    void largeCollectionIsCappedWithMoreSuffix() {
+        // Build a 25-entity body so the cap (20) trims and the +N-more suffix fires. The exact
+        // cap is intentionally not asserted here — it's a tunable; the contract is that very
+        // large collections never emit one line per entity.
+        StringBuilder body = new StringBuilder("{\"value\":[");
+        for (int i = 0; i < 25; i++) {
+            if (i > 0) {
+                body.append(',');
+            }
+            body.append("{\"id\":\"g").append(i).append("\",\"displayName\":\"name").append(i).append("\"}");
+        }
+        body.append("]}");
+
+        String summary = GraphConnector.summarizeJsonResponse(body.toString());
+
+        assertThat(summary).startsWith("25 entities:");
+        assertThat(summary)
+                .as("the +N-more suffix must point operators at the verbose toggle")
+                .contains("... +5 more")
+                .contains("verboseGraphLog");
+        // The first entry must be present; the last entry beyond the cap must NOT be inlined.
+        assertThat(summary).contains("displayName=\"name0\"");
+        assertThat(summary).doesNotContain("displayName=\"name24\"");
+    }
+
+    @Test
+    void paginatedCollectionAnnotatesHeader() {
+        String body = """
+                {
+                    "@odata.nextLink": "https://graph.microsoft.com/v1.0/groups?$skiptoken=...",
+                    "value": [
+                        {"id": "g1", "displayName": "A"}
+                    ]
+                }
+                """;
+
+        String summary = GraphConnector.summarizeJsonResponse(body);
+
+        assertThat(summary).contains("(paginated)");
+    }
+
+    @Test
+    void emptyCollectionRendersHeaderOnly() {
+        String body = "{\"value\": []}";
+
+        String summary = GraphConnector.summarizeJsonResponse(body);
+
+        assertThat(summary).isEqualTo("0 entities");
+    }
+
+    @Test
+    void singleEntityResponseKeepsFullPrettyPrintedJson() {
+        // Responses without a value array (e.g. /organization, /users/{id}) are kept full —
+        // those payloads are bounded in size and the entire JSON is the most useful view.
+        String body = "{\"id\": \"org-1\", \"displayName\": \"Contoso\", \"verifiedDomains\": [{\"name\": \"contoso.com\"}]}";
+
+        String summary = GraphConnector.summarizeJsonResponse(body);
+
+        // Pretty-printed → contains a newline immediately after the leading separator, plus
+        // every field of the original payload (including nested arrays).
+        assertThat(summary).startsWith(System.lineSeparator() + "{");
+        assertThat(summary)
+                .contains("\"displayName\": \"Contoso\"")
+                .contains("\"verifiedDomains\"")
+                .contains("\"contoso.com\"");
+    }
+
+    @Test
+    void malformedBodyFallsBackToTruncatedRaw() {
+        // A 5KB string with no JSON shape: the summarizer must not throw — it returns a
+        // truncated raw dump pointing at the verbose toggle so the operator still has a
+        // diagnostic anchor.
+        String body = "x".repeat(5_000);
+
+        String summary = GraphConnector.summarizeJsonResponse(body);
+
+        assertThat(summary)
+                .as("malformed body must be truncated, not emitted in full")
+                .startsWith("xxxx")
+                .contains("more chars")
+                .contains("verboseGraphLog");
+        assertThat(summary.length()).isLessThan(body.length());
+    }
+
+    @Test
+    void shortMalformedBodyIsReturnedVerbatim() {
+        // The truncation logic must only kick in past the cap; short non-JSON bodies are
+        // emitted verbatim so the operator sees exactly what came back.
+        String body = "<html>service unavailable</html>";
+
+        String summary = GraphConnector.summarizeJsonResponse(body);
+
+        assertThat(summary).isEqualTo(body);
+    }
+}

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorResponseSummaryTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorResponseSummaryTest.java
@@ -103,14 +103,14 @@ class GraphConnectorResponseSummaryTest {
 
         String summary = GraphConnector.summarizeJsonResponse(body.toString());
 
-        assertThat(summary).startsWith("25 entities:");
+        // Single chained assertion: count header, +N-more suffix pointing at the verbose toggle,
+        // first entry inlined, and last entry beyond the cap NOT inlined.
         assertThat(summary)
-                .as("the +N-more suffix must point operators at the verbose toggle")
+                .startsWith("25 entities:")
                 .contains("... +5 more")
-                .contains("verboseGraphLog");
-        // The first entry must be present; the last entry beyond the cap must NOT be inlined.
-        assertThat(summary).contains("displayName=\"name0\"");
-        assertThat(summary).doesNotContain("displayName=\"name24\"");
+                .contains("verboseGraphLog")
+                .contains("displayName=\"name0\"")
+                .doesNotContain("displayName=\"name24\"");
     }
 
     @Test
@@ -148,8 +148,8 @@ class GraphConnectorResponseSummaryTest {
 
         // Pretty-printed → contains a newline immediately after the leading separator, plus
         // every field of the original payload (including nested arrays).
-        assertThat(summary).startsWith(System.lineSeparator() + "{");
         assertThat(summary)
+                .startsWith(System.lineSeparator() + "{")
                 .contains("\"displayName\": \"Contoso\"")
                 .contains("\"verifiedDomains\"")
                 .contains("\"contoso.com\"");

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/connector/GraphConnectorTest.java
@@ -384,6 +384,28 @@ class GraphConnectorTest {
     }
 
     @Test
+    void setVerboseLogTogglesResponseLoggingShape(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
+        // The verboseGraphLog job parameter flows through GraphConnector#setVerboseLog and
+        // switches getResponseContent between the compact summary (default) and the legacy
+        // pretty-printed full payload. The actual log content is asserted at unit level in
+        // GraphConnectorResponseSummaryTest; here we just exercise the toggle end-to-end through
+        // a real request so JaCoCo records the setter body and the verbose dispatch branch in
+        // getResponseContent.
+        mockGetGroupsCall("groups.json", 200);
+        GraphConnector connector = createConnector(wmRuntimeInfo);
+        connector.setVerboseLog(true);
+
+        List<Group> verboseFirst = connector.getGroups(groupPrefix);
+
+        connector.setVerboseLog(false);
+        List<Group> compactSecond = connector.getGroups(groupPrefix);
+
+        assertThat(verboseFirst)
+                .as("toggling the log shape must not change the resolved entities")
+                .hasSameSizeAs(compactSecond);
+    }
+
+    @Test
     void getGroupsOmitsServerSideFilterWhenPrefixIsBlank(WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
         // When only groupPatterns is configured (and no prefixes), the connector must fetch all
         // groups: no $filter query parameter on the Graph request. The job then narrows the

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPatternsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPatternsTest.java
@@ -2,47 +2,70 @@ package ch.sbb.polarion.extension.aad.synchronizer.model;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Covers every shape Polarion can deliver to the {@code <groupPatterns>} parameter constructor.
- * Mirrors {@link GroupPrefixesTest} — the two wrappers share the same conversion logic and
- * differ only in the inner element name, so any divergence between them is suspicious and
- * must surface in this test pair.
+ * Mirrors {@link GroupPrefixesTest} for the {@code <groupPatterns>} block. The two wrappers share
+ * the same Polarion-shape dispatch logic and differ only in the inner element name, so any
+ * divergence between this pair of tests is suspicious. See {@link GroupPrefixesTest} for the
+ * shape catalog.
  */
 class GroupPatternsTest {
 
     @Test
-    void nullMapYieldsEmptyList() {
-        assertThat(new GroupPatterns(null).getPatterns()).isEmpty();
+    void fromRawValue_nullYieldsNull() {
+        assertThat(GroupPatterns.fromRawValue(null)).isNull();
     }
 
     @Test
-    void missingKeyYieldsEmptyList() {
-        assertThat(new GroupPatterns(Map.of("unrelated", "value")).getPatterns()).isEmpty();
+    void fromRawValue_unexpectedScalarYieldsNull() {
+        assertThat(GroupPatterns.fromRawValue(42)).isNull();
+        assertThat(GroupPatterns.fromRawValue("not-a-shape")).isNull();
     }
 
     @Test
-    void singleStringChildYieldsSingletonList() {
-        GroupPatterns patterns = new GroupPatterns(Map.of(
-                GroupPatterns.GROUP_PATTERN_NAME, "^FOO_.*"));
+    void fromRawValue_singleChildMapYieldsSingletonList() {
+        GroupPatterns patterns = (GroupPatterns) GroupPatterns.fromRawValue(
+                Map.of(GroupPatterns.GROUP_PATTERN_NAME, "^FOO_.*"));
 
         assertThat(patterns.getPatterns()).containsExactly("^FOO_.*");
     }
 
     @Test
-    void multipleChildrenYieldList() {
-        GroupPatterns patterns = new GroupPatterns(Map.of(
-                GroupPatterns.GROUP_PATTERN_NAME, List.of("^A_.*", "^B_.*")));
+    void fromRawValue_multipleChildrenListYieldsList() {
+        GroupPatterns patterns = (GroupPatterns) GroupPatterns.fromRawValue(
+                List.of("^A_.*", "^B_.*"));
 
         assertThat(patterns.getPatterns()).containsExactly("^A_.*", "^B_.*");
     }
 
     @Test
-    void unexpectedValueTypeYieldsEmptyList() {
-        assertThat(new GroupPatterns(Map.of(GroupPatterns.GROUP_PATTERN_NAME, 42)).getPatterns()).isEmpty();
+    void fromRawValue_mapWithMissingInnerKeyYieldsEmptyList() {
+        GroupPatterns patterns = (GroupPatterns) GroupPatterns.fromRawValue(
+                Map.of("unrelated", "value"));
+
+        assertThat(patterns.getPatterns()).isEmpty();
+    }
+
+    @Test
+    void fromRawValue_mapWithUnexpectedInnerTypeYieldsEmptyList() {
+        GroupPatterns patterns = (GroupPatterns) GroupPatterns.fromRawValue(
+                Map.of(GroupPatterns.GROUP_PATTERN_NAME, 42));
+
+        assertThat(patterns.getPatterns()).isEmpty();
+    }
+
+    @Test
+    void directConstructorPreservesOrderAndTakesDefensiveCopy() {
+        java.util.ArrayList<String> source = new java.util.ArrayList<>(Arrays.asList("^KEEP_.*", null, ""));
+        GroupPatterns patterns = new GroupPatterns(source);
+
+        assertThat(patterns.getPatterns()).containsExactly("^KEEP_.*", null, "");
+        source.add("^LATE_ADDITION_.*");
+        assertThat(patterns.getPatterns()).containsExactly("^KEEP_.*", null, "");
     }
 }

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPatternsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPatternsTest.java
@@ -44,6 +44,15 @@ class GroupPatternsTest {
     }
 
     @Test
+    void fromRawValue_mapWithListUnderInnerKeyYieldsList() {
+        // Mirror of GroupPrefixesTest's defensive Map-wrapping-List case.
+        GroupPatterns patterns = (GroupPatterns) GroupPatterns.fromRawValue(
+                Map.of(GroupPatterns.GROUP_PATTERN_NAME, List.of("^A_.*", "^B_.*")));
+
+        assertThat(patterns.getPatterns()).containsExactly("^A_.*", "^B_.*");
+    }
+
+    @Test
     void fromRawValue_mapWithMissingInnerKeyYieldsEmptyList() {
         GroupPatterns patterns = (GroupPatterns) GroupPatterns.fromRawValue(
                 Map.of("unrelated", "value"));

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPrefixesTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPrefixesTest.java
@@ -52,6 +52,18 @@ class GroupPrefixesTest {
     }
 
     @Test
+    void fromRawValue_mapWithListUnderInnerKeyYieldsList() {
+        // Defensive shape: a Map-wrapping-List arrives when an operator nests homogeneously-named
+        // children inside the leaf — e.g. <groupPrefixes><groupPrefix><sub>A</sub><sub>B</sub></groupPrefix></groupPrefixes>
+        // (atypical but Polarion's parseParameter delivers it as {groupPrefix=[A, B]}). The
+        // wrapper must accept this without falling through to the empty-default branch.
+        GroupPrefixes prefixes = (GroupPrefixes) GroupPrefixes.fromRawValue(
+                Map.of(GroupPrefixes.GROUP_PREFIX_NAME, List.of("A_", "B_")));
+
+        assertThat(prefixes.getPrefixes()).containsExactly("A_", "B_");
+    }
+
+    @Test
     void fromRawValue_mapWithMissingInnerKeyYieldsEmptyList() {
         // Defensive: a Map without the expected inner-tag key shouldn't throw — the job's
         // mutual-exclusion logic treats an empty-prefix wrapper as "not provided".

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPrefixesTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/model/GroupPrefixesTest.java
@@ -2,52 +2,86 @@ package ch.sbb.polarion.extension.aad.synchronizer.model;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Covers every shape Polarion can deliver to the {@code <groupPrefixes>} parameter constructor:
- * {@code null} map, missing key, single-child case (Polarion delivers the inner element as a
- * bare {@link String} when only one is present), multi-child case (delivered as a {@link List}),
- * and the wrong-type fallback that protects against future changes in Polarion's parameter
- * marshalling.
+ * Covers every shape Polarion's
+ * {@code com.polarion.platform.jobs.internal.service.scheduler.ScheduleDataHandler#parseParameter}
+ * can deliver for a {@code <groupPrefixes>} block. The shape varies with the child structure:
+ * one child → {@code Map}, two-or-more same-tag children → bare {@code List}, empty/absent → blank
+ * {@code String} or {@code null}. The bare-{@code List} case is the regression that motivated
+ * this fix; it must not be silently dropped (see
+ * {@code GroupPrefixesPolarionShapeRegressionTest} for an end-to-end XML check).
  */
 class GroupPrefixesTest {
 
     @Test
-    void nullMapYieldsEmptyList() {
-        assertThat(new GroupPrefixes(null).getPrefixes()).isEmpty();
+    void fromRawValue_nullYieldsNull() {
+        assertThat(GroupPrefixes.fromRawValue(null)).isNull();
     }
 
     @Test
-    void missingKeyYieldsEmptyList() {
-        assertThat(new GroupPrefixes(Map.of("unrelated", "value")).getPrefixes()).isEmpty();
+    void fromRawValue_unexpectedScalarYieldsNull() {
+        // Defensive: a stray scalar (Integer, plain String, …) is treated as "not provided".
+        assertThat(GroupPrefixes.fromRawValue(42)).isNull();
+        assertThat(GroupPrefixes.fromRawValue("not-a-shape")).isNull();
     }
 
     @Test
-    void singleStringChildYieldsSingletonList() {
-        // Polarion collapses <groupPrefixes><groupPrefix>X</groupPrefix></groupPrefixes>
-        // to a bare String under the inner element name — wrapper must promote it to a list.
-        GroupPrefixes prefixes = new GroupPrefixes(Map.of(GroupPrefixes.GROUP_PREFIX_NAME, "ONE_"));
+    void fromRawValue_singleChildMapYieldsSingletonList() {
+        // <groupPrefixes><groupPrefix>X</groupPrefix></groupPrefixes>
+        // → ScheduleDataHandler#parseMapParameter produces {groupPrefix=X}.
+        GroupPrefixes prefixes = (GroupPrefixes) GroupPrefixes.fromRawValue(
+                Map.of(GroupPrefixes.GROUP_PREFIX_NAME, "ONE_"));
 
         assertThat(prefixes.getPrefixes()).containsExactly("ONE_");
     }
 
     @Test
-    void multipleChildrenYieldList() {
-        GroupPrefixes prefixes = new GroupPrefixes(Map.of(
-                GroupPrefixes.GROUP_PREFIX_NAME, List.of("LEGACY_", "NEW_")));
+    void fromRawValue_multipleChildrenListYieldsList() {
+        // <groupPrefixes><groupPrefix>A_</groupPrefix><groupPrefix>B_</groupPrefix></groupPrefixes>
+        // → ScheduleDataHandler#parseListParameter produces ["A_", "B_"] (the inner tag name
+        // is dropped). This is the shape a previous Map-only convertValue silently dropped.
+        GroupPrefixes prefixes = (GroupPrefixes) GroupPrefixes.fromRawValue(List.of("A_", "B_"));
 
-        assertThat(prefixes.getPrefixes()).containsExactly("LEGACY_", "NEW_");
+        assertThat(prefixes.getPrefixes()).containsExactly("A_", "B_");
     }
 
     @Test
-    void unexpectedValueTypeYieldsEmptyList() {
-        // Defensive: if a future Polarion release ever delivers a Map or Number under the inner
-        // element key (not currently possible, but the type signature allows it), the wrapper
-        // must not throw — empty list keeps the job init's mutual-exclusion logic well-defined.
-        assertThat(new GroupPrefixes(Map.of(GroupPrefixes.GROUP_PREFIX_NAME, 42)).getPrefixes()).isEmpty();
+    void fromRawValue_mapWithMissingInnerKeyYieldsEmptyList() {
+        // Defensive: a Map without the expected inner-tag key shouldn't throw — the job's
+        // mutual-exclusion logic treats an empty-prefix wrapper as "not provided".
+        GroupPrefixes prefixes = (GroupPrefixes) GroupPrefixes.fromRawValue(
+                Map.of("unrelated", "value"));
+
+        assertThat(prefixes.getPrefixes()).isEmpty();
+    }
+
+    @Test
+    void fromRawValue_mapWithUnexpectedInnerTypeYieldsEmptyList() {
+        // Defensive: if a future Polarion release ever delivered a non-String/non-List value
+        // under the inner key, we degrade to an empty wrapper rather than crashing during
+        // parameter conversion.
+        GroupPrefixes prefixes = (GroupPrefixes) GroupPrefixes.fromRawValue(
+                Map.of(GroupPrefixes.GROUP_PREFIX_NAME, 42));
+
+        assertThat(prefixes.getPrefixes()).isEmpty();
+    }
+
+    @Test
+    void directConstructorPreservesOrderAndTakesDefensiveCopy() {
+        // Production direct-set / test setup goes through the public constructor. Nulls must be
+        // preserved at this layer (UserSynchronizationJobUnit init drops them); the wrapper must
+        // not share storage with the caller's list.
+        java.util.ArrayList<String> source = new java.util.ArrayList<>(Arrays.asList("KEEP_", null, ""));
+        GroupPrefixes prefixes = new GroupPrefixes(source);
+
+        assertThat(prefixes.getPrefixes()).containsExactly("KEEP_", null, "");
+        source.add("LATE_ADDITION_");
+        assertThat(prefixes.getPrefixes()).containsExactly("KEEP_", null, "");
     }
 }

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/service/GraphServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/service/GraphServiceTest.java
@@ -181,7 +181,8 @@ class GraphServiceTest {
 
     @Test
     void prefixesAndPatterns_throwWhenUnionIsEmpty() {
-        // Both branches yield nothing → the union is empty and the run must fail loudly.
+        // Both branches yield nothing → the union is empty and the run must fail loudly with a
+        // message that lists both selectors as configured.
         when(graphConnector.getGroups(List.of("MISSING_")))
                 .thenThrow(new NotFoundException("No AAD groups were found."));
         when(graphConnector.getGroups(List.of())).thenReturn(List.of(new Group("g1", "UNRELATED")));
@@ -193,6 +194,22 @@ class GraphServiceTest {
         assertThatThrownBy(() -> service.getAadMemberIds(prefixes, patterns))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("groupPrefixes/groupPatterns");
+    }
+
+    @Test
+    void patternsOnly_throwMessageMentionsOnlyConfiguredSelector() {
+        // Patterns-only path: when the regex matches nothing, the failure message must reference
+        // groupPatterns alone. Prior to this contract the unified message ("groupPrefixes/...")
+        // misled operators who hadn't configured groupPrefixes at all.
+        when(graphConnector.getGroups(List.of())).thenReturn(List.of(new Group("g1", "UNRELATED")));
+
+        List<Pattern> patterns = List.of(Pattern.compile("^WILL_NOT_MATCH$"));
+        GraphService service = new GraphService(graphConnector);
+
+        assertThatThrownBy(() -> service.getAadMemberIds(List.of(), patterns))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("groupPatterns")
+                .hasMessageNotContaining("groupPrefixes");
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/service/GraphServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/service/GraphServiceTest.java
@@ -147,9 +147,9 @@ class GraphServiceTest {
 
     @Test
     void prefixesAndPatterns_recoverWhenPrefixesMatchNothing() {
-        // Empty prefix result alone would throw NotFoundException from GraphConnector#getGroups;
-        // when patterns are also configured the union may still be non-empty, so the prefix
-        // branch failure is swallowed and the pattern branch carries the run.
+        // An empty prefix result alone surfaces as NotFoundException from the connector. With
+        // patterns also configured, the union may still be non-empty — so the prefix branch
+        // failure is swallowed and the pattern branch carries the run.
         when(graphConnector.getGroups(List.of("MISSING_")))
                 .thenThrow(new NotFoundException("No AAD groups were found."));
         when(graphConnector.getGroups(List.of())).thenReturn(List.of(new Group("g1", "PATTERN_HIT")));
@@ -170,8 +170,10 @@ class GraphServiceTest {
         when(graphConnector.getGroups(List.of("MISSING_")))
                 .thenThrow(new NotFoundException("No AAD groups were found."));
         GraphService service = new GraphService(graphConnector);
+        List<String> prefixes = List.of("MISSING_");
+        List<Pattern> patterns = List.of();
 
-        assertThatThrownBy(() -> service.getAadMemberIds(List.of("MISSING_"), List.of()))
+        assertThatThrownBy(() -> service.getAadMemberIds(prefixes, patterns))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("No AAD groups were found");
         verify(graphConnector, never()).getGroups(List.of());
@@ -184,10 +186,11 @@ class GraphServiceTest {
                 .thenThrow(new NotFoundException("No AAD groups were found."));
         when(graphConnector.getGroups(List.of())).thenReturn(List.of(new Group("g1", "UNRELATED")));
 
+        List<String> prefixes = List.of("MISSING_");
         List<Pattern> patterns = List.of(Pattern.compile("^WILL_NOT_MATCH$"));
         GraphService service = new GraphService(graphConnector);
 
-        assertThatThrownBy(() -> service.getAadMemberIds(List.of("MISSING_"), patterns))
+        assertThatThrownBy(() -> service.getAadMemberIds(prefixes, patterns))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("groupPrefixes/groupPatterns");
     }

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/service/GraphServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/service/GraphServiceTest.java
@@ -26,6 +26,8 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -37,7 +39,7 @@ class GraphServiceTest {
     private static Stream<Arguments> testValues() {
 
         Map<String, List<Member>> map1 = new HashMap<>();
-        map1.put("1", List.of(new Member("1","name", "mail"),
+        map1.put("1", List.of(new Member("1", "name", "mail"),
                 new Member("2", "name", "mail")));
         map1.put("2", List.of(new Member("3", "name", "mail"),
                 new Member("4", "name", "mail")));
@@ -61,8 +63,7 @@ class GraphServiceTest {
 
     @ParameterizedTest
     @MethodSource("testValues")
-    void testGetAadMemberIds(List<Group> groups, Map<String, List<Member>> membersInGroupMap, List<String> expected) {
-
+    void prefixesOnly_dedupsMembersAcrossGroups(List<Group> groups, Map<String, List<Member>> membersInGroupMap, List<String> expected) {
         GraphService service = new GraphService(graphConnector);
         List<String> prefixes = List.of("SOME_");
         when(graphConnector.getGroups(prefixes)).thenReturn(groups);
@@ -76,85 +77,123 @@ class GraphServiceTest {
     }
 
     @Test
-    void testGetAadMemberIdsAppliesGroupPatterns() {
-        // groupPatterns narrow the server-side result client-side: a group passes when ANY of the
-        // configured patterns matches its displayName fully. Example: match SOME_ and SOME_OTHER_
-        // prefixes while excluding SOME_IGNORED_.
-        Group keep1 = new Group("g1", "SOME_GROUP_PREFIX_A");
-        Group keep2 = new Group("g2", "SOME_OTHER_GROUP_PREFIX_B");
-        Group drop = new Group("g3", "SOME_IGNORED_GROUP_PREFIX_C");
-
-        List<String> prefixes = List.of("SOME");
-        when(graphConnector.getGroups(prefixes)).thenReturn(List.of(keep1, keep2, drop));
-        when(graphConnector.getMembers("g1")).thenReturn(List.of(new Member("m1", "n", "e")));
-        when(graphConnector.getMembers("g2")).thenReturn(List.of(new Member("m2", "n", "e")));
-
-        Pattern pattern = Pattern.compile("^SOME(_OTHER)?_GROUP_PREFIX_.*");
-        GraphService service = new GraphService(graphConnector);
-
-        List<String> members = new ArrayList<>(service.getAadMemberIds(prefixes, List.of(pattern)));
-
-        assertThat(members).containsExactlyInAnyOrder("m1", "m2");
-    }
-
-    @Test
-    void testGetAadMemberIdsCombinesMultiplePatternsWithOr() {
-        // Multiple patterns are OR-combined: a group is kept if ANY pattern matches. Verifies the
-        // anyMatch wiring so two disjoint regexes can be supplied without fusing them into one
-        // alternation manually.
-        Group a = new Group("g1", "ALPHA_TEAM");
-        Group b = new Group("g2", "BETA_TEAM");
-        Group c = new Group("g3", "GAMMA_TEAM");
-
-        List<String> prefixes = List.of();
-        when(graphConnector.getGroups(prefixes)).thenReturn(List.of(a, b, c));
+    void patternsOnly_fetchesAllGroupsAndFiltersClientSide() {
+        // No prefix → connector is called with an empty list (the "fetch all groups" path); the
+        // regex then narrows server result client-side. Verifies both that the unfiltered fetch
+        // is the wiring used and that anyMatch is the combinator across multiple patterns.
+        Group alpha = new Group("g1", "ALPHA_TEAM");
+        Group beta = new Group("g2", "BETA_TEAM");
+        Group gamma = new Group("g3", "GAMMA_TEAM");
+        when(graphConnector.getGroups(List.of())).thenReturn(List.of(alpha, beta, gamma));
         when(graphConnector.getMembers("g1")).thenReturn(List.of(new Member("ma", "n", "e")));
         when(graphConnector.getMembers("g2")).thenReturn(List.of(new Member("mb", "n", "e")));
 
         List<Pattern> patterns = List.of(Pattern.compile("^ALPHA_.*"), Pattern.compile("^BETA_.*"));
         GraphService service = new GraphService(graphConnector);
 
-        List<String> members = new ArrayList<>(service.getAadMemberIds(prefixes, patterns));
+        List<String> members = new ArrayList<>(service.getAadMemberIds(List.of(), patterns));
 
         assertThat(members).containsExactlyInAnyOrder("ma", "mb");
     }
 
     @Test
-    void testGetAadMemberIdsRaisesWhenPatternMatchesNothing() {
-        // If the regex filters out every group the connector returned, the job must fail loudly
-        // instead of silently producing an empty member set (which would later wipe Polarion).
-        Group g = new Group("g1", "SOME_IGNORED_GROUP_PREFIX_A");
-        List<String> prefixes = List.of("SOME");
-        when(graphConnector.getGroups(prefixes)).thenReturn(List.of(g));
+    void patternsOnly_skipsGroupsWithoutDisplayName() {
+        // Defensive: a Group without a displayName (e.g. an external IGraphConnector
+        // implementation that doesn't populate it) must not blow up the regex match — it just
+        // doesn't match anything.
+        Group named = new Group("g1", "ALPHA_TEAM");
+        Group unnamed = new Group("g2");
+        when(graphConnector.getGroups(List.of())).thenReturn(List.of(named, unnamed));
+        when(graphConnector.getMembers("g1")).thenReturn(List.of(new Member("ma", "n", "e")));
 
-        List<Pattern> patterns = List.of(Pattern.compile("^SOME(_OTHER)?_GROUP_PREFIX_.*"));
+        Pattern pattern = Pattern.compile("^ALPHA_.*");
         GraphService service = new GraphService(graphConnector);
 
-        assertThatThrownBy(() -> service.getAadMemberIds(prefixes, patterns))
-                .isInstanceOf(NotFoundException.class)
-                .hasMessageContaining("groupPatterns");
+        List<String> members = new ArrayList<>(service.getAadMemberIds(List.of(), List.of(pattern)));
+
+        assertThat(members).containsExactly("ma");
     }
 
     @Test
-    void testGetAadMemberIdsTolerantToMissingDisplayName() {
-        // Defensive: a Group without a displayName (e.g. external IGraphConnector implementation
-        // not populating it) must not blow up — it just doesn't match any pattern.
-        Group named = new Group("g1", "SOME_GROUP_PREFIX_A");
-        Group unnamed = new Group("g2");
-        List<String> prefixes = List.of("SOME");
-        when(graphConnector.getGroups(prefixes)).thenReturn(List.of(named, unnamed));
-        when(graphConnector.getMembers("g1")).thenReturn(List.of(new Member("m1", "n", "e")));
+    void prefixesAndPatterns_unionsTwoIndependentFetches() {
+        // Documents the union semantics introduced for the prefixes+patterns case: prefixes fetch
+        // a server-filtered set and patterns fetch the full tenant + filter client-side; the
+        // results are unioned by group id. Useful when an operator wants a broad family of groups
+        // by prefix plus a handful of outliers captured only by a regex.
+        Group prefixOnly = new Group("g-prefix", "TEAM_ALPHA");
+        Group patternOnly = new Group("g-pattern", "ADMIN_SPECIAL");
+        Group inBoth = new Group("g-both", "TEAM_BETA");
 
-        Pattern pattern = Pattern.compile("^SOME_GROUP_PREFIX_.*");
+        // Prefix branch: server-side $filter on "TEAM_" returns the two TEAM_ groups.
+        when(graphConnector.getGroups(List.of("TEAM_"))).thenReturn(List.of(prefixOnly, inBoth));
+        // Pattern branch: unfiltered fetch returns the entire tenant; the regex below selects
+        // ADMIN_SPECIAL plus TEAM_BETA. TEAM_BETA appears in both branches and must be deduped.
+        when(graphConnector.getGroups(List.of())).thenReturn(List.of(prefixOnly, inBoth, patternOnly));
+        when(graphConnector.getMembers("g-prefix")).thenReturn(List.of(new Member("m-prefix", "n", "e")));
+        when(graphConnector.getMembers("g-pattern")).thenReturn(List.of(new Member("m-pattern", "n", "e")));
+        when(graphConnector.getMembers("g-both")).thenReturn(List.of(new Member("m-both", "n", "e")));
+
+        List<Pattern> patterns = List.of(Pattern.compile("^ADMIN_SPECIAL$"), Pattern.compile("^TEAM_BETA$"));
         GraphService service = new GraphService(graphConnector);
 
-        List<String> members = new ArrayList<>(service.getAadMemberIds(prefixes, List.of(pattern)));
+        List<String> members = new ArrayList<>(service.getAadMemberIds(List.of("TEAM_"), patterns));
+
+        assertThat(members).containsExactlyInAnyOrder("m-prefix", "m-pattern", "m-both");
+        // g-both is in both branches; getMembers must be invoked once, not twice. Verifies the
+        // group dedup happens before member resolution rather than relying on the member set's
+        // own dedup.
+        verify(graphConnector).getMembers("g-both");
+    }
+
+    @Test
+    void prefixesAndPatterns_recoverWhenPrefixesMatchNothing() {
+        // Empty prefix result alone would throw NotFoundException from GraphConnector#getGroups;
+        // when patterns are also configured the union may still be non-empty, so the prefix
+        // branch failure is swallowed and the pattern branch carries the run.
+        when(graphConnector.getGroups(List.of("MISSING_")))
+                .thenThrow(new NotFoundException("No AAD groups were found."));
+        when(graphConnector.getGroups(List.of())).thenReturn(List.of(new Group("g1", "PATTERN_HIT")));
+        when(graphConnector.getMembers("g1")).thenReturn(List.of(new Member("m1", "n", "e")));
+
+        List<Pattern> patterns = List.of(Pattern.compile("^PATTERN_HIT$"));
+        GraphService service = new GraphService(graphConnector);
+
+        List<String> members = new ArrayList<>(service.getAadMemberIds(List.of("MISSING_"), patterns));
 
         assertThat(members).containsExactly("m1");
     }
 
     @Test
-    void testCheckLastSynchronization() {
+    void prefixesOnly_propagatesNotFoundFromConnector() {
+        // Without patterns the prefix branch is the only signal; an empty result must surface as
+        // NotFoundException so the run fails loudly instead of wiping Polarion silently.
+        when(graphConnector.getGroups(List.of("MISSING_")))
+                .thenThrow(new NotFoundException("No AAD groups were found."));
+        GraphService service = new GraphService(graphConnector);
+
+        assertThatThrownBy(() -> service.getAadMemberIds(List.of("MISSING_"), List.of()))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("No AAD groups were found");
+        verify(graphConnector, never()).getGroups(List.of());
+    }
+
+    @Test
+    void prefixesAndPatterns_throwWhenUnionIsEmpty() {
+        // Both branches yield nothing → the union is empty and the run must fail loudly.
+        when(graphConnector.getGroups(List.of("MISSING_")))
+                .thenThrow(new NotFoundException("No AAD groups were found."));
+        when(graphConnector.getGroups(List.of())).thenReturn(List.of(new Group("g1", "UNRELATED")));
+
+        List<Pattern> patterns = List.of(Pattern.compile("^WILL_NOT_MATCH$"));
+        GraphService service = new GraphService(graphConnector);
+
+        assertThatThrownBy(() -> service.getAadMemberIds(List.of("MISSING_"), patterns))
+                .isInstanceOf(NotFoundException.class)
+                .hasMessageContaining("groupPrefixes/groupPatterns");
+    }
+
+    @Test
+    void checkLastSynchronization() {
         Date date = new Date();
         GraphService service = new GraphService(graphConnector);
         OrganizationData data = new OrganizationData(date);

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/service/GraphServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/service/GraphServiceTest.java
@@ -203,10 +203,11 @@ class GraphServiceTest {
         // misled operators who hadn't configured groupPrefixes at all.
         when(graphConnector.getGroups(List.of())).thenReturn(List.of(new Group("g1", "UNRELATED")));
 
+        List<String> prefixes = List.of();
         List<Pattern> patterns = List.of(Pattern.compile("^WILL_NOT_MATCH$"));
         GraphService service = new GraphService(graphConnector);
 
-        assertThatThrownBy(() -> service.getAadMemberIds(List.of(), patterns))
+        assertThatThrownBy(() -> service.getAadMemberIds(prefixes, patterns))
                 .isInstanceOf(NotFoundException.class)
                 .hasMessageContaining("groupPatterns")
                 .hasMessageNotContaining("groupPrefixes");


### PR DESCRIPTION
### Proposed changes

This pull request introduces a new logging mode for Microsoft Graph API responses, allowing operators to toggle between a compact summary and a full verbose JSON dump for diagnostics. It also clarifies and updates the documentation and parameter handling for group selection logic, especially regarding the interaction between group prefix and group pattern selectors.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
