### PR TITLE
feat!: remove the deprecated legacy single prefix form groupPrefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,19 +240,7 @@ extension owned by an AAD application with id `abc123de-f456-7890-abcd-ef1234567
   both naming conventions in a single selector. Invalid regex fails the job at start with a
   clear error and the offending pattern.
 
-> [!WARNING]
-> The legacy single-prefix form `<groupPrefix>SOME_</groupPrefix>` is **deprecated** and
-> will be **removed in the next major release**. Migrate existing configurations to the
-> plural wrapper:
-> ```xml
-> <groupPrefixes>
->     <groupPrefix>SOME_</groupPrefix>
-> </groupPrefixes>
-> ```
-> The two forms are mutually exclusive — set one or the other, not both. When the legacy
-> form is used, the job logs a deprecation warning at every run.
-
-At least one of `groupPrefix`, `groupPrefixes`, or `groupPatterns` must be provided. The two
+At least one of `groupPrefixes` or `groupPatterns` must be provided. The two
 selectors are independent OR-sources and produce a **union** of groups:
 
 - `groupPrefixes` only — one Graph request with a server-side `startswith($filter)`.

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnit.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnit.java
@@ -18,14 +18,6 @@ public interface AADUserSynchronizationJobUnit extends IJobUnit {
 
     void setGraphEmailField(String graphEmailField);
 
-    /**
-     * @deprecated Legacy single-prefix form, kept only for backwards compatibility with existing
-     * job configurations. Use {@link #setGroupPrefixes(GroupPrefixes)} instead. Scheduled for
-     * removal in the next major release.
-     */
-    @Deprecated(forRemoval = true)
-    void setGroupPrefix(String groupPrefix);
-
     void setGroupPrefixes(GroupPrefixes groupPrefixes);
 
     void setGroupPatterns(GroupPatterns groupPatterns);

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactory.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactory.java
@@ -19,7 +19,6 @@ public class AADUserSynchronizationJobUnitFactory implements IJobUnitFactory {
     public static final String GRAPH_ID_FIELD = "graphIdField";
     public static final String GRAPH_NAME_FIELD = "graphNameField";
     public static final String GRAPH_EMAIL_FIELD = "graphEmailField";
-    public static final String GROUP_PREFIX = "groupPrefix";
     public static final String GROUP_PREFIXES = "groupPrefixes";
     public static final String GROUP_PATTERNS = "groupPatterns";
     public static final String WHITELIST = "whitelist";
@@ -67,17 +66,11 @@ public class AADUserSynchronizationJobUnitFactory implements IJobUnitFactory {
                 "Overrides the Microsoft Graph user property used as the email. When unset, the <email> from authentication.xml <mapping> is used.",
                 stringType).setRequired(false));
 
-        desc.addParameter(new SimpleJobParameter(
-                desc.getRootParameterGroup(),
-                GROUP_PREFIX,
-                "DEPRECATED — will be removed in the next major release. Use <groupPrefixes><groupPrefix>...</groupPrefix></groupPrefixes> instead. Legacy single-prefix form, kept for backwards compatibility with existing job configurations. Translated to a server-side startswith(displayName, ...) filter on Microsoft Graph. Mutually exclusive with <groupPrefixes>. At least one of groupPrefix/groupPrefixes/groupPatterns must be provided.",
-                stringType).setRequired(false));
-
         desc.addParameter(
                 new SimpleJobParameter(
                         desc.getRootParameterGroup(),
                         GROUP_PREFIXES,
-                        "List of literal AAD group prefixes (XML: <groupPrefixes><groupPrefix>...</groupPrefix>...</groupPrefixes>). Translated to a single Microsoft Graph $filter combining startswith(displayName, ...) clauses with OR. Up to 15 prefixes are accepted (Graph rejects larger expressions with HTTP 400). Mutually exclusive with the legacy singular <groupPrefix>.",
+                        "List of literal AAD group prefixes (XML: <groupPrefixes><groupPrefix>...</groupPrefix>...</groupPrefixes>). Translated to a single Microsoft Graph $filter combining startswith(displayName, ...) clauses with OR. Up to 15 prefixes are accepted (Graph rejects larger expressions with HTTP 400).",
                         new JobParameterPrimitiveType("GroupPrefixes", GroupPrefixes.class)
                 ) {
                     @Override
@@ -91,7 +84,7 @@ public class AADUserSynchronizationJobUnitFactory implements IJobUnitFactory {
                 new SimpleJobParameter(
                         desc.getRootParameterGroup(),
                         GROUP_PATTERNS,
-                        "List of regular expressions matched client-side against the AAD group displayName (full match, java.util.regex). XML: <groupPatterns><groupPattern>...</groupPattern>...</groupPatterns>. A group is included if any pattern matches. Use to match disjoint naming conventions in a single selector, e.g. ^(LEGACY|NEW)_TEAM_.* . Combined with groupPrefix(es) the two selectors act as independent OR-sources: prefixes fetch a server-filtered set, patterns fetch the full tenant + filter client-side, results are unioned by group id. At least one of groupPrefix/groupPrefixes/groupPatterns must be provided.",
+                        "List of regular expressions matched client-side against the AAD group displayName (full match, java.util.regex). XML: <groupPatterns><groupPattern>...</groupPattern>...</groupPatterns>. A group is included if any pattern matches. Use to match disjoint naming conventions in a single selector, e.g. ^(LEGACY|NEW)_TEAM_.* . Combined with groupPrefixes the two selectors act as independent OR-sources: prefixes fetch a server-filtered set, patterns fetch the full tenant + filter client-side, results are unioned by group id. At least one of groupPrefixes/groupPatterns must be provided.",
                         new JobParameterPrimitiveType("GroupPatterns", GroupPatterns.class)
                 ) {
                     @Override

--- a/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnit.java
+++ b/src/main/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnit.java
@@ -47,7 +47,6 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
     private String graphNameField;
     private String graphEmailField;
     private IOAuth2SecurityConfiguration authenticationProviderConfiguration;
-    private String groupPrefix;
     private GroupPrefixes groupPrefixes;
     private GroupPatterns groupPatterns;
     private List<String> effectivePrefixes = Collections.emptyList();
@@ -83,14 +82,6 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
                 "|                    DRY RUN                    |" :
                 "|                    REAL RUN                   |");
         JobLogger.getInstance().separator();
-
-        if (!isParameterNotProvided(groupPrefix)) {
-            JobLogger.getInstance().log(
-                    "WARNING: <groupPrefix> is deprecated and will be removed in the next major release. "
-                            + "Migrate to <groupPrefixes><groupPrefix>%s</groupPrefix></groupPrefixes>.",
-                    groupPrefix);
-            JobLogger.getInstance().separator();
-        }
 
         if (externalGraphConnector != null) {
             JobLogger.getInstance().log("Using external graph connector: " + externalGraphConnector.getClass());
@@ -192,29 +183,22 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
         }
         this.authenticationProviderConfiguration = findAuthenticationProviderConfiguration(authenticationProviderId);
 
-        boolean hasLegacyPrefix = !isParameterNotProvided(groupPrefix);
         List<String> pluralPrefixes = groupPrefixes == null ? Collections.emptyList() : groupPrefixes.getPrefixes();
         List<String> rawPatterns = groupPatterns == null ? Collections.emptyList() : groupPatterns.getPatterns();
 
-        validateGroupSelectorsProvided(hasLegacyPrefix, pluralPrefixes, rawPatterns);
+        validateGroupSelectorsProvided(pluralPrefixes, rawPatterns);
 
-        this.effectivePrefixes = resolveEffectivePrefixes(hasLegacyPrefix, pluralPrefixes);
+        this.effectivePrefixes = resolveEffectivePrefixes(pluralPrefixes);
         this.compiledPatterns = compilePatterns(rawPatterns);
     }
 
-    private void validateGroupSelectorsProvided(boolean hasLegacyPrefix, List<String> pluralPrefixes, List<String> rawPatterns) {
-        if (hasLegacyPrefix && !pluralPrefixes.isEmpty()) {
-            throw new NotFoundException("Job properties contain both <groupPrefix> and <groupPrefixes>; use only one (prefer <groupPrefixes>).");
-        }
-        if (!hasLegacyPrefix && pluralPrefixes.isEmpty() && rawPatterns.isEmpty()) {
-            throw new NotFoundException("At least one of <groupPrefix>, <groupPrefixes>, or <groupPatterns> should be provided via job properties");
+    private void validateGroupSelectorsProvided(List<String> pluralPrefixes, List<String> rawPatterns) {
+        if (pluralPrefixes.isEmpty() && rawPatterns.isEmpty()) {
+            throw new NotFoundException("At least one of <groupPrefixes> or <groupPatterns> should be provided via job properties");
         }
     }
 
-    private List<String> resolveEffectivePrefixes(boolean hasLegacyPrefix, List<String> pluralPrefixes) {
-        if (hasLegacyPrefix) {
-            return List.of(groupPrefix);
-        }
+    private List<String> resolveEffectivePrefixes(List<String> pluralPrefixes) {
         // Drop blank entries so accidental empty <groupPrefix/> children in the XML don't
         // generate broken startswith(displayName, '') clauses (which would match every group).
         List<String> cleaned = pluralPrefixes.stream()
@@ -281,16 +265,6 @@ public class UserSynchronizationJobUnit extends AbstractJobUnit implements AADUs
     @Override
     public void setGraphEmailField(String graphEmailField) {
         this.graphEmailField = graphEmailField;
-    }
-
-    /**
-     * @deprecated Legacy single-prefix setter, scheduled for removal in the next major release.
-     * Use {@link #setGroupPrefixes(GroupPrefixes)} instead.
-     */
-    @Override
-    @Deprecated(forRemoval = true)
-    public void setGroupPrefix(String prefix) {
-        this.groupPrefix = prefix;
     }
 
     @Override

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/AADSynchronizerAdminUiServletTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/AADSynchronizerAdminUiServletTest.java
@@ -1,0 +1,16 @@
+package ch.sbb.polarion.extension.aad.synchronizer;
+
+import ch.sbb.polarion.extension.generic.GenericUiServlet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AADSynchronizerAdminUiServletTest {
+
+    @Test
+    void instantiatesAsGenericUiServlet() {
+        AADSynchronizerAdminUiServlet servlet = new AADSynchronizerAdminUiServlet();
+
+        assertThat(servlet).isInstanceOf(GenericUiServlet.class);
+    }
+}

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactoryTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/AADUserSynchronizationJobUnitFactoryTest.java
@@ -22,7 +22,7 @@ class AADUserSynchronizationJobUnitFactoryTest {
         IJobDescriptor descriptor = factory.getJobDescriptor(null);
 
         assertThat(descriptor.getLabel()).isEqualTo("Synchronization job");
-        Stream.of(AUTHENTICATION_PROVIDER_ID, GROUP_PREFIX, GROUP_PREFIXES, GROUP_PATTERNS,
+        Stream.of(AUTHENTICATION_PROVIDER_ID, GROUP_PREFIXES, GROUP_PATTERNS,
                 DRY_RUN, CHECK_LAST_SYNCHRONIZATION, VERBOSE_GRAPH_LOG,
                 GRAPH_ID_FIELD, GRAPH_NAME_FIELD, GRAPH_EMAIL_FIELD).forEach(
                 param -> assertThat(descriptor.getParameter(param)).isNotNull()

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnitTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnitTest.java
@@ -44,7 +44,6 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-@SuppressWarnings({"deprecation", "removal"}) // exercises legacy <groupPrefix> path on purpose; drop with the deprecated method
 class UserSynchronizationJobUnitTest {
     @Mock
     private IJobUnitFactory jobUnitFactory;
@@ -66,7 +65,7 @@ class UserSynchronizationJobUnitTest {
     void setup() {
         userSynchronizationJobUnit = new UserSynchronizationJobUnit("testName", jobUnitFactory, authenticationProviderConfiguration, securityService, projectService, externalGraphConnector);
         userSynchronizationJobUnit.setAuthenticationProviderId("authenticationProviderId");
-        userSynchronizationJobUnit.setGroupPrefix("testPrefix");
+        userSynchronizationJobUnit.setGroupPrefixes(new GroupPrefixes(List.of("testPrefix")));
         // Exercise the Graph field override setters so SonarQube counts them as covered. The
         // values are irrelevant for the externalGraphConnector path but the setter bodies must
         // execute at least once; the resolver itself is tested in GraphConnectorTest.
@@ -126,7 +125,7 @@ class UserSynchronizationJobUnitTest {
                 "testName", jobUnitFactory, authenticationProviderConfiguration,
                 securityService, projectService, null);
         jobUnit.setAuthenticationProviderId("authenticationProviderId");
-        jobUnit.setGroupPrefix("testPrefix");
+        jobUnit.setGroupPrefixes(new GroupPrefixes(List.of("testPrefix")));
         jobUnit.setGraphIdField("onPremisesSamAccountName");
         jobUnit.setJob(mock(IJob.class));
 
@@ -201,7 +200,6 @@ class UserSynchronizationJobUnitTest {
     void shouldFailWhenNoGroupSelectorProvided() {
         // Validation contract: at least one of groupPrefix / groupPrefixes / groupPatterns must
         // be set, otherwise the job has no way to scope which AAD groups to read.
-        userSynchronizationJobUnit.setGroupPrefix(null);
         userSynchronizationJobUnit.setGroupPrefixes(null);
         userSynchronizationJobUnit.setGroupPatterns(null);
 
@@ -214,26 +212,10 @@ class UserSynchronizationJobUnitTest {
     }
 
     @Test
-    void shouldFailWhenLegacyAndPluralPrefixesAreBothSet() {
-        // Mutual exclusion: if a deployer is migrating to <groupPrefixes>, accidentally leaving
-        // the legacy <groupPrefix> in place must surface as a configuration error rather than
-        // silently picking one of the two.
-        userSynchronizationJobUnit.setGroupPrefix("legacyPrefix");
-        userSynchronizationJobUnit.setGroupPrefixes(new GroupPrefixes(List.of("A_", "B_")));
-
-        try (MockedStatic<AuthenticationManager> mockedAuthenticationManager = Mockito.mockStatic(AuthenticationManager.class, RETURNS_DEEP_STUBS)) {
-            mockedAuthenticationManager.when(() -> AuthenticationManager.getInstance().authenticators())
-                    .thenReturn(List.of(authenticationProviderConfiguration));
-
-            callRunInternalAndVerifyException("both <groupPrefix> and <groupPrefixes>");
-        }
-    }
-
-    @Test
     void shouldFailOnInvalidGroupPattern() {
         // An invalid regex should fail the job at start with a clear configuration error rather
         // than throwing PatternSyntaxException deep inside the run.
-        userSynchronizationJobUnit.setGroupPrefix(null);
+        userSynchronizationJobUnit.setGroupPrefixes(null);
         userSynchronizationJobUnit.setGroupPatterns(new GroupPatterns(List.of("[invalid(")));
 
         try (MockedStatic<AuthenticationManager> mockedAuthenticationManager = Mockito.mockStatic(AuthenticationManager.class, RETURNS_DEEP_STUBS)) {
@@ -253,7 +235,6 @@ class UserSynchronizationJobUnitTest {
         for (int i = 0; i < 16; i++) {
             tooMany.add("PREFIX_" + i + "_");
         }
-        userSynchronizationJobUnit.setGroupPrefix(null);
         userSynchronizationJobUnit.setGroupPrefixes(new GroupPrefixes(tooMany));
 
         try (MockedStatic<AuthenticationManager> mockedAuthenticationManager = Mockito.mockStatic(AuthenticationManager.class, RETURNS_DEEP_STUBS)) {
@@ -270,7 +251,7 @@ class UserSynchronizationJobUnitTest {
         // Pattern-only configuration: no server-side prefix, regex applied client-side. Verifies
         // the pattern actually filters groups before resolving members and that only patterns
         // (no prefixes) is a valid configuration.
-        userSynchronizationJobUnit.setGroupPrefix(null);
+        userSynchronizationJobUnit.setGroupPrefixes(null);
         userSynchronizationJobUnit.setGroupPatterns(new GroupPatterns(List.of("^SOME(_OTHER)?_GROUP_PREFIX_.*")));
 
         try (MockedStatic<TransactionalExecutor> mockedExecutor = Mockito.mockStatic(TransactionalExecutor.class);
@@ -313,9 +294,6 @@ class UserSynchronizationJobUnitTest {
     @SuppressWarnings("unchecked")
     void shouldRunWithMultipleGroupPrefixes() {
         // Plural <groupPrefixes>: connector receives the full list and OR-combines server-side.
-        // The legacy singular setter must NOT be set in the same job (mutual exclusion is covered
-        // by a dedicated test above), so reset it here.
-        userSynchronizationJobUnit.setGroupPrefix(null);
         userSynchronizationJobUnit.setGroupPrefixes(new GroupPrefixes(List.of("LEGACY_", "NEW_")));
 
         try (MockedStatic<TransactionalExecutor> mockedExecutor = Mockito.mockStatic(TransactionalExecutor.class);
@@ -368,7 +346,6 @@ class UserSynchronizationJobUnitTest {
         patternsWithBlanks.add("");
         patternsWithBlanks.add("   ");
 
-        userSynchronizationJobUnit.setGroupPrefix(null);
         userSynchronizationJobUnit.setGroupPrefixes(new GroupPrefixes(prefixesWithBlanks));
         userSynchronizationJobUnit.setGroupPatterns(new GroupPatterns(patternsWithBlanks));
 

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnitTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/UserSynchronizationJobUnitTest.java
@@ -198,8 +198,8 @@ class UserSynchronizationJobUnitTest {
 
     @Test
     void shouldFailWhenNoGroupSelectorProvided() {
-        // Validation contract: at least one of groupPrefix / groupPrefixes / groupPatterns must
-        // be set, otherwise the job has no way to scope which AAD groups to read.
+        // Validation contract: at least one of groupPrefixes / groupPatterns must be set,
+        // otherwise the job has no way to scope which AAD groups to read.
         userSynchronizationJobUnit.setGroupPrefixes(null);
         userSynchronizationJobUnit.setGroupPatterns(null);
 
@@ -207,7 +207,7 @@ class UserSynchronizationJobUnitTest {
             mockedAuthenticationManager.when(() -> AuthenticationManager.getInstance().authenticators())
                     .thenReturn(List.of(authenticationProviderConfiguration));
 
-            callRunInternalAndVerifyException("groupPrefix");
+            callRunInternalAndVerifyException("groupPrefixes");
         }
     }
 

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/rest/AADSynchronizerRestApplicationTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/rest/AADSynchronizerRestApplicationTest.java
@@ -1,0 +1,16 @@
+package ch.sbb.polarion.extension.aad.synchronizer.rest;
+
+import ch.sbb.polarion.extension.generic.rest.GenericRestApplication;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AADSynchronizerRestApplicationTest {
+
+    @Test
+    void instantiatesAsGenericRestApplication() {
+        AADSynchronizerRestApplication application = new AADSynchronizerRestApplication();
+
+        assertThat(application).isInstanceOf(GenericRestApplication.class);
+    }
+}

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/rest/OpenAPIInfoTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/rest/OpenAPIInfoTest.java
@@ -1,0 +1,19 @@
+package ch.sbb.polarion.extension.aad.synchronizer.rest;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OpenAPIInfoTest {
+
+    @Test
+    void instantiatesAndCarriesOpenAPIDefinition() {
+        assertThat(new OpenAPIInfo()).isNotNull();
+
+        OpenAPIDefinition definition = OpenAPIInfo.class.getAnnotation(OpenAPIDefinition.class);
+        assertThat(definition).isNotNull();
+        assertThat(definition.info().title()).isEqualTo("AAD Synchronizer REST API");
+        assertThat(definition.info().version()).isEqualTo("v1");
+    }
+}

--- a/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/utils/CollectionUtilsTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/aad/synchronizer/utils/CollectionUtilsTest.java
@@ -1,0 +1,31 @@
+package ch.sbb.polarion.extension.aad.synchronizer.utils;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CollectionUtilsTest {
+
+    @Test
+    void nullListYieldsEmptyString() {
+        assertThat(CollectionUtils.usersAsString(null)).isEmpty();
+    }
+
+    @Test
+    void emptyListYieldsEmptyString() {
+        assertThat(CollectionUtils.usersAsString(List.of())).isEmpty();
+    }
+
+    @Test
+    void singleUserIsQuotedWithoutBrackets() {
+        assertThat(CollectionUtils.usersAsString(List.of("alice"))).isEqualTo("'alice'");
+    }
+
+    @Test
+    void multipleUsersAreQuotedAndBracketed() {
+        assertThat(CollectionUtils.usersAsString(List.of("alice", "bob", "carol")))
+                .isEqualTo("['alice', 'bob', 'carol']");
+    }
+}


### PR DESCRIPTION
### Proposed changes

This pull request removes support for the deprecated legacy `<groupPrefix>` configuration in favor of the plural `<groupPrefixes>` and `<groupPatterns>` forms, simplifying both the codebase and the user-facing documentation. It also cleans up related code, updates tests, and adds new tests for servlet and REST application instantiation.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
