### PR TITLE
build: bump react-sbb-polarion to 0.0.10

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,7 +8,7 @@
       "name": "aad-synchronizer-app",
       "version": "1.0.0",
       "dependencies": {
-        "@grigoriev/react-sbb-polarion": "^0.0.9",
+        "@grigoriev/react-sbb-polarion": "^0.0.10",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
@@ -506,9 +506,9 @@
       }
     },
     "node_modules/@grigoriev/react-sbb-polarion": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@grigoriev/react-sbb-polarion/-/react-sbb-polarion-0.0.9.tgz",
-      "integrity": "sha512-ZgRCDEIwpwLp2FNacBchyROQv69RJErVZipbq7PocYhOK+WMU0k0swMm/mMKer6A3N66/h0PeR2zcnsZj4p9Zw==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@grigoriev/react-sbb-polarion/-/react-sbb-polarion-0.0.10.tgz",
+      "integrity": "sha512-9PLhDeB8l6Z/6ElNQL01cwnUbd6DPyduJA6BsJ2bi5cqGe2nhZUrIATEL9XQg6w0tg0frxpxq7IwhjOKo8ku3g==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20.9.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,7 +21,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@grigoriev/react-sbb-polarion": "^0.0.9",
+    "@grigoriev/react-sbb-polarion": "^0.0.10",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },


### PR DESCRIPTION
### Proposed changes

Bumps react-sbb-polarion to 0.0.10, which replaces the browser's `window.confirm` with a styled
confirmation dialog built on the shared `Modal`. This extension has no confirmation of its own, so it
only needs the dependency bump to stay on the same RSP release as the rest of the extensions.

The bump has to be explicit: a caret range on a `0.x.y` version pins the patch, so `^0.0.9` never
resolves to 0.0.10.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
